### PR TITLE
fix-execute-proposal

### DIFF
--- a/apps/web/app/(app)/gardens/[chain]/[garden]/pool/[poolId]/page.tsx
+++ b/apps/web/app/(app)/gardens/[chain]/[garden]/pool/[poolId]/page.tsx
@@ -157,6 +157,7 @@ export default async function Pool({
             alloInfo={alloInfo}
             communityAddress={communityAddress}
             createProposalUrl={`/gardens/${chain}/${garden}/pool/${poolId}/create-proposal`}
+            proposalType={proposalType}
           />
         </main>
       </div>

--- a/apps/web/components/Proposals.tsx
+++ b/apps/web/components/Proposals.tsx
@@ -8,6 +8,7 @@ import {
   useContractWrite,
   Address as AddressType,
   useContractRead,
+  useWaitForTransaction,
 } from "wagmi";
 import { encodeFunctionParams } from "@/utils/encodeFunctionParams";
 import { alloABI, cvStrategyABI, registryCommunityABI } from "@/src/generated";
@@ -248,7 +249,7 @@ export function Proposals({
     return encodedProposalId;
   };
 
-  //test executing a proposal with distribute function
+  //executing proposal distribute function / alert error if not executable / notification if success
   const {
     data: distributeData,
     write: writeDistribute,
@@ -268,6 +269,24 @@ export function Proposals({
       alert("NOT EXECUTABLE:" + "  " + distributeErrorName.errorName);
     }
   }, [isErrorDistribute]);
+
+  const {
+    updateTransactionStatus: updateDistributeTransactionStatus,
+    txConfirmationHash: distributeTxConfirmationHash,
+  } = useTransactionNotification(distributeData);
+
+  const {
+    data: waitDistributeData,
+    isSuccess: isWaitDistributeSuccess,
+    status: isWaitDistributeStatus,
+  } = useWaitForTransaction({
+    hash: distributeData?.hash,
+    confirmations: 1,
+  });
+
+  useEffect(() => {
+    updateDistributeTransactionStatus(isWaitDistributeStatus);
+  }, [isWaitDistributeStatus]);
   //
 
   useErrorDetails(errorAllocate, "errorAllocate");
@@ -276,7 +295,7 @@ export function Proposals({
 
   useEffect(() => {
     triggerRenderProposals();
-  }, [txConfirmationHash]);
+  }, [txConfirmationHash, distributeTxConfirmationHash]);
 
   useEffect(() => {
     updateTransactionStatus(allocateStatus);

--- a/apps/web/components/Proposals.tsx
+++ b/apps/web/components/Proposals.tsx
@@ -61,11 +61,13 @@ export function Proposals({
   alloInfo,
   communityAddress,
   createProposalUrl,
+  proposalType,
 }: {
   strategy: Strategy;
   alloInfo: AlloQuery;
   communityAddress: Address;
   createProposalUrl: string;
+  proposalType: number;
 }) {
   const DECIMALS = strategy.registryCommunity.garden.decimals;
 
@@ -92,6 +94,8 @@ export function Proposals({
   const urqlClient = useUrqlClient();
   const chainId = getChainIdFromPath();
 
+  const isSignalingProposal = proposalType == 0;
+
   const registryContractCallConfig = {
     address: communityAddress,
     abi: abiWithErrors2(registryCommunityABI),
@@ -103,13 +107,6 @@ export function Proposals({
     args: [address as Address, strategy.id as Address],
     watch: true,
   });
-
-  // const { data: checking } = useContractRead({
-  //   address: strategy.id as Address,
-  //   abi: abiWithErrors(cvStrategyABI),
-  //   functionName: "canExecuteProposal",
-  //   args: [5],
-  // });
 
   const runIsMemberQuery = useCallback(async () => {
     if (address === undefined) {
@@ -453,7 +450,7 @@ export function Proposals({
                 <div className="flex items-center gap-8">
                   <StatusBadge status={proposalStatus} />
                   {/* Button to test distribute */}
-                  {!editView && (
+                  {!editView && !isSignalingProposal && (
                     <Button
                       // TODO: add flexible tooltip and func to check executability
                       disabled={

--- a/apps/web/components/Proposals.tsx
+++ b/apps/web/components/Proposals.tsx
@@ -254,16 +254,23 @@ export function Proposals({
     write: writeDistribute,
     error: errorDistribute,
     isSuccess: isSuccessDistribute,
+    isError: isErrorDistribute,
     status: distributeStatus,
   } = useContractWrite({
     address: alloInfo.id as Address,
     abi: abiWithErrors(alloABI),
     functionName: "distribute",
   });
+
+  const distributeErrorName = useErrorDetails(errorDistribute);
+  useEffect(() => {
+    if (isErrorDistribute && distributeErrorName.errorName !== undefined) {
+      alert("NOT EXECUTABLE:" + "  " + distributeErrorName.errorName);
+    }
+  }, [isErrorDistribute]);
   //
 
   useErrorDetails(errorAllocate, "errorAllocate");
-
   const { updateTransactionStatus, txConfirmationHash } =
     useTransactionNotification(allocateData);
 
@@ -342,20 +349,6 @@ export function Proposals({
   const { tooltipMessage, isConnected, missmatchUrl } = useDisableButtons(
     disableManageSupportBtnCondition,
   );
-
-  //Execute Disable Button condition => message mapping
-  // const disableExecuteBtnCondition: ConditionObject[] = [
-  //   {
-  //     condition: proposals.some((proposal) => proposal.proposalStatus == "4"),
-  //     message: "Proposal already executed",
-  //   },
-  // ];
-  // const disableExecuteButton = disableExecuteBtnCondition.some(
-  //   (cond) => cond.condition,
-  // );
-  // const tooltipMessageExecuteBtn = useDisableButtons(
-  //   disableExecuteBtnCondition,
-  // );
 
   return (
     <section className="rounded-lg border-2 border-black bg-white p-12">
@@ -471,7 +464,7 @@ export function Proposals({
                         })
                       }
                     >
-                      Execute proposal
+                      Execute
                     </Button>
                   )}
                   <>

--- a/apps/web/components/Proposals.tsx
+++ b/apps/web/components/Proposals.tsx
@@ -34,6 +34,7 @@ import { getChainIdFromPath } from "@/utils/path";
 import { useDisableButtons, ConditionObject } from "@/hooks/useDisableButtons";
 import { useUrqlClient } from "@/hooks/useUqrlClient";
 import { FormLink } from "@/components";
+import { toast } from "react-toastify";
 
 type InputItem = {
   id: string;
@@ -266,7 +267,7 @@ export function Proposals({
   const distributeErrorName = useErrorDetails(errorDistribute);
   useEffect(() => {
     if (isErrorDistribute && distributeErrorName.errorName !== undefined) {
-      alert("NOT EXECUTABLE:" + "  " + distributeErrorName.errorName);
+      toast.error("NOT EXECUTABLE:" + "  " + distributeErrorName.errorName);
     }
   }, [isErrorDistribute]);
 
@@ -285,8 +286,8 @@ export function Proposals({
   });
 
   useEffect(() => {
-    updateDistributeTransactionStatus(isWaitDistributeStatus);
-  }, [isWaitDistributeStatus]);
+    updateDistributeTransactionStatus(distributeStatus);
+  }, [distributeStatus]);
   //
 
   useErrorDetails(errorAllocate, "errorAllocate");


### PR DESCRIPTION
#155 

- a toast error notification is open when member try to execute a proposal that NOT reach threshold: with error name "ProposalUnderMinumunThreshold"

- a toast error notification is open when user try to execute a proposal already Executed: error name "ProposalNotActive". This is momentary until we fix the subgraph for proposalStatus. Upon fix, the button will be already disabled and the status badge set to "executed"