### PR TITLE
Show dispute modal even if not active

### DIFF
--- a/apps/web/components/DisputeButton.tsx
+++ b/apps/web/components/DisputeButton.tsx
@@ -115,29 +115,23 @@ export const DisputeButton: FC<Props> = ({ proposalData }) => {
     arbitrationCost && config ?
       arbitrationCost + BigInt(config.challengerCollateralAmount)
     : undefined;
-
   const lastDispute =
     disputesResult?.proposalDisputes[
       disputesResult?.proposalDisputes.length - 1
     ];
-
   const isCooldown =
     !!lastDispute &&
     !!disputeCooldown &&
     +lastDispute.ruledAt + Number(disputeCooldown) > Date.now() / 1000;
-
+  const proposalStatus = ProposalStatus[proposalData.proposalStatus];
   const isDisputed =
-    proposalData &&
-    lastDispute &&
-    ProposalStatus[proposalData.proposalStatus] === "disputed";
-
+    proposalData && lastDispute && proposalStatus === "disputed";
   const isTimeout =
     lastDispute &&
     config &&
     +lastDispute.createdAt + +config.defaultRulingTimeout < Date.now() / 1000;
-
   const disputes = disputesResult?.proposalDisputes ?? [];
-
+  const isProposalEnded = proposalStatus !== "active" && !isDisputed;
   const isTribunalSafe = config.tribunalSafe === address?.toLowerCase();
 
   const { data: isTribunalMember } = useContractRead({
@@ -248,7 +242,7 @@ export const DisputeButton: FC<Props> = ({ proposalData }) => {
 
   const content = (
     <div className="flex md:flex-col gap-10">
-      {isDisputed ?
+      {proposalStatus !== "active" ?
         <div className="p-16 rounded-lg">
           {disputes.map((dispute) => (
             <Fragment key={dispute.id}>
@@ -402,8 +396,7 @@ export const DisputeButton: FC<Props> = ({ proposalData }) => {
 
   return (
     <>
-      {(ProposalStatus[proposalData?.proposalStatus] === "active" ||
-        ProposalStatus[proposalData?.proposalStatus] === "disputed") && (
+      {(proposalStatus === "active" || lastDispute != null) && (
         <>
           <Button
             color="danger"
@@ -412,7 +405,7 @@ export const DisputeButton: FC<Props> = ({ proposalData }) => {
             disabled={isDisconnected}
             tooltip="Connect wallet"
           >
-            {isDisputed ? "Open dispute" : "Dispute"}
+            {isDisputed ?? isProposalEnded ? "Open dispute" : "Dispute"}
           </Button>
           <Modal
             title={`Disputed Proposal: ${proposalData.title} #${proposalData.proposalNumber}`}
@@ -420,7 +413,7 @@ export const DisputeButton: FC<Props> = ({ proposalData }) => {
             isOpen={isModalOpened}
           >
             {content}
-            {buttons}
+            {!isProposalEnded && buttons}
           </Modal>
         </>
       )}


### PR DESCRIPTION
When a proposal has been disputed we should have access of the reason and ruling outcome, it is now always possible to open the dispute modal with the reason chat and timeline when a proposal is ended and has already been disputed.