### PR TITLE
Filter & sorting proposals in pool page

### DIFF
--- a/apps/web/components/Proposals.tsx
+++ b/apps/web/components/Proposals.tsx
@@ -1118,7 +1118,7 @@ function ProposalFiltersUI({
           <p className="text-sm text-neutral-soft-content">Sort by</p>
         </div>
         <div className="dropdown dropdown-hover dropdown-start  w-full relative group">
-          <button className="text-primary-content text-sm  flex gap-2 items-center w-full lg:w-[255px] px-3.5 py-2 bg-primary rounded-lg">
+          <button className="text-primary-content text-sm  flex gap-2 items-center w-full lg:w-[255px] px-3.5 py-2 bg-primary-soft dark:bg-primary rounded-lg">
             {CurrentIcon && <CurrentIcon className="w-4 h-4" />}
             {currentSortOption?.label}
           </button>


### PR DESCRIPTION
Filter and Sorting UX/UI. -> Clean and quick status filters with sort by 5 options aside. Active status and sort by most conviction as defaults.

When there are NO proposal yet in pool, this component is not shown. 

Also I group: download proposals conviction button with add create proposal next to a ". . . " icon to keep UI cleaner 