### PR TITLE
Fix coverage workflow submodule init cleanup

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -40,7 +40,12 @@ jobs:
           run_install: false
 
       - name: Init required submodules
-        run: git submodule update --init --recursive --depth 1 --jobs 4
+        run: |
+          # Cleanup for clones that still have the removed octant submodule cached.
+          git config --local --remove-section submodule.lib/octant-v2-core || true
+          rm -rf .git/modules/lib/octant-v2-core lib/octant-v2-core
+          git submodule sync --recursive
+          git submodule update --init --recursive --depth 1 --jobs 4
 
       - name: Run coverage
         run: pnpm --dir pkg/contracts run coverage


### PR DESCRIPTION
### Motivation
- Prevent CI failures where runners with cached `.git/modules` state see `fatal: No url found for submodule path 'lib/octant-v2-core' in .gitmodules` due to stale octant submodule metadata.

### Description
- Update `.github/workflows/coverage.yml` to proactively remove the stale submodule config with `git config --local --remove-section submodule.lib/octant-v2-core || true`, delete `.git/modules/lib/octant-v2-core` and `lib/octant-v2-core`, run `git submodule sync --recursive`, and then run `git submodule update --init --recursive --depth 1 --jobs 4`.

### Testing
- Ran the CI submodule init locally via `git submodule update --init --recursive --depth 1 --jobs 4` after the workflow change and the command completed successfully without the `octant-v2-core` url error.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69972ae04c0c832d98d2ff53faae2c37)