### PR TITLE
Align campaign detail page with ended campaign state

### DIFF
--- a/apps/web/app/(app)/gardens/campaigns/[campaignId]/client-page.tsx
+++ b/apps/web/app/(app)/gardens/campaigns/[campaignId]/client-page.tsx
@@ -212,6 +212,7 @@ export default function GardensGrowthInitiativePage({
   const [openModal, setOpenModal] = useState(false);
 
   const campaigns = CAMPAIGNS[campaignId];
+  const isEndedCampaign = !isCampaignActive(campaigns, Date.now());
 
   const howToParticipate = PARTICIPATION_BY_CAMPAIGN[campaignId];
 
@@ -296,10 +297,15 @@ export default function GardensGrowthInitiativePage({
             src={campaigns?.banner}
             alt="Gardens Growth Initiative"
             fill
-            className="object-cover"
+            className={`object-cover ${isEndedCampaign ? "grayscale" : ""}`}
             priority
           />
           <div className="absolute inset-0 bg-gradient-to-b from-neutral/5 via-neutral to-neutral/5 dark:from-neutral/30 dark:to-neutral/30" />
+          {isEndedCampaign && (
+            <div className="absolute inset-x-0 top-0 bg-danger py-2 text-center text-xs font-extrabold uppercase tracking-[0.2em] text-white shadow-lg">
+              Campaign Ended
+            </div>
+          )}
         </div>
 
         <div className="relative mx-auto max-w-7xl px-4 py-16 sm:px-6 lg:px-8">
@@ -333,7 +339,7 @@ export default function GardensGrowthInitiativePage({
                 <div className="flex items-center gap-2 text-sm">
                   <CalendarIcon className="h-6 w-6 " />
                   <span className="font-semibold">
-                    Ends {campaigns?.endDate}
+                    {isEndedCampaign ? "Ended" : "Ends"} {campaigns?.endDate}
                   </span>
                 </div>
 
@@ -581,4 +587,21 @@ export default function GardensGrowthInitiativePage({
       </div>
     </div>
   );
+}
+
+function isCampaignActive(
+  campaign: (typeof CAMPAIGNS)[keyof typeof CAMPAIGNS] | undefined,
+  referenceTimestamp: number,
+) {
+  if (!campaign) {
+    return false;
+  }
+
+  const endDateTimestamp = Date.parse(campaign.endDate);
+
+  if (Number.isNaN(endDateTimestamp)) {
+    return false;
+  }
+
+  return endDateTimestamp >= referenceTimestamp;
 }


### PR DESCRIPTION
### Motivation
- Ensure the campaign detail page visually matches the campaigns list for campaigns that have ended by surfacing an explicit ended state.
- Make the detail view resilient to invalid or missing end dates by centralizing status logic.

### Description
- Compute an `isEndedCampaign` flag in the campaign detail page using a new `isCampaignActive` helper that parses the campaign `endDate` and compares it to `Date.now()`; the helper returns `false` on missing/invalid dates.
- Apply ended visual treatment to the hero banner by adding a grayscale class and a top `Campaign Ended` ribbon when `isEndedCampaign` is true.
- Update the hero date label to show `Ended {date}` for ended campaigns and keep `Ends {date}` for active campaigns.
- Changed file: `apps/web/app/(app)/gardens/campaigns/[campaignId]/client-page.tsx` and added the local `isCampaignActive` function.

### Testing
- Ran ESLint on the modified file with `pnpm -C apps/web exec eslint "app/(app)/gardens/campaigns/[campaignId]/client-page.tsx"` and it passed.
- Attempted to run the app with `pnpm -C apps/web dev`, but compilation surfaced an unrelated existing module resolution error (`@/src/generated`) in other components which blocked full runtime validation.
- Attempted to capture a Playwright screenshot of the page, but the browser tooling timed out and no artifact was produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a069d7f324832d8f8faa65d0e1fcb5)