### PR TITLE
Potential fix for code scanning alert no. 19: Server-side request forgery

### DIFF
--- a/apps/web/app/api/superfluid-points-gd/leaderboard/route.ts
+++ b/apps/web/app/api/superfluid-points-gd/leaderboard/route.ts
@@ -17,6 +17,12 @@ const normalizeGateway = (gw?: string | null) => {
   }
   return `https://${trimmed}`;
 };
+
+const isValidCid = (value: string): boolean => {
+  const cid = value.trim();
+  // Allow common CIDv0/CIDv1 textual forms only (base58btc/base32 lowercase chars).
+  return /^[A-Za-z0-9]{46,120}$/.test(cid);
+};
 const IPFS_GATEWAY = normalizeGateway(process.env.IPFS_GATEWAY);
 const SUPERFLUID_CHAIN_ID = 8453;
 const PINATA_JWT = process.env.PINATA_JWT;
@@ -94,9 +100,10 @@ const fetchSuperfluidTotals = async (): Promise<number | null> => {
 };
 
 const fetchIpfsJson = async <T = any>(cid: string): Promise<T | null> => {
-  if (!cid) return null;
+  if (!cid || !isValidCid(cid)) return null;
   try {
-    const res = await fetch(`${IPFS_GATEWAY}/ipfs/${cid}`);
+    const ipfsUrl = new URL(`/ipfs/${encodeURIComponent(cid)}`, IPFS_GATEWAY).toString();
+    const res = await fetch(ipfsUrl);
     if (!res.ok) {
       console.warn("[leaderboard-gd] ipfs fetch failed", {
         cid,
@@ -205,6 +212,13 @@ export async function GET(request: Request) {
       campaignIdFromQuery ?
         `${PINATA_POINTS_SNAPSHOT_NAME}-${campaignIdFromQuery}`
       : PINATA_POINTS_SNAPSHOT_NAME;
+    if (cidFromQuery && !isValidCid(cidFromQuery)) {
+      return NextResponse.json(
+        { error: "Invalid cid parameter" },
+        { status: 400 },
+      );
+    }
+
     const cid =
       cidFromQuery ??
       (campaignIdFromQuery ? null : PINATA_POINTS_SNAPSHOT_CID) ??

--- a/apps/web/app/api/superfluid-points-gd/leaderboard/route.ts
+++ b/apps/web/app/api/superfluid-points-gd/leaderboard/route.ts
@@ -2,6 +2,7 @@ import pinataSDK from "@pinata/sdk";
 import { NextResponse } from "next/server";
 import { createClient, fetchExchange, gql } from "urql";
 import { chainConfigMap } from "@/configs/chains";
+import { isValidCid, buildIpfsUrl } from "@/utils/ipfs";
 
 const PINATA_POINTS_SNAPSHOT_NAME = "superfluid-activity-points-gd";
 const PINATA_POINTS_SNAPSHOT_CID =
@@ -18,11 +19,6 @@ const normalizeGateway = (gw?: string | null) => {
   return `https://${trimmed}`;
 };
 
-const isValidCid = (value: string): boolean => {
-  const cid = value.trim();
-  // Allow common CIDv0/CIDv1 textual forms only (base58btc/base32 lowercase chars).
-  return /^[A-Za-z0-9]{46,120}$/.test(cid);
-};
 const IPFS_GATEWAY = normalizeGateway(process.env.IPFS_GATEWAY);
 const SUPERFLUID_CHAIN_ID = 8453;
 const PINATA_JWT = process.env.PINATA_JWT;
@@ -102,7 +98,7 @@ const fetchSuperfluidTotals = async (): Promise<number | null> => {
 const fetchIpfsJson = async <T = any>(cid: string): Promise<T | null> => {
   if (!cid || !isValidCid(cid)) return null;
   try {
-    const ipfsUrl = new URL(`/ipfs/${encodeURIComponent(cid)}`, IPFS_GATEWAY).toString();
+    const ipfsUrl = buildIpfsUrl(IPFS_GATEWAY, cid);
     const res = await fetch(ipfsUrl);
     if (!res.ok) {
       console.warn("[leaderboard-gd] ipfs fetch failed", {

--- a/apps/web/app/api/superfluid-points-gd/route.ts
+++ b/apps/web/app/api/superfluid-points-gd/route.ts
@@ -11,6 +11,7 @@ import { getSuperfluidPointsClientByEnv } from "@/services/superfluid-points";
 import { erc20ABI } from "@/src/generated";
 import { ChainId } from "@/types";
 import { getViemChain } from "@/utils/web3";
+import { isValidCid } from "@/utils/ipfs";
 
 type Strategy = {
   id: Address;
@@ -1024,11 +1025,11 @@ const ensureLatestTransferCacheCid = async (): Promise<string | null> => {
 const fetchIpfsJson = async (
   cid: string,
 ): Promise<{ entries?: Record<string, string | null> } | null> => {
-  if (!CAN_READ_IPFS || !cid) return null;
+  if (!CAN_READ_IPFS || !cid || !isValidCid(cid)) return null;
   try {
     const gateway =
       IPFS_GATEWAY?.replace(/\/$/, "") ?? "https://gateway.pinata.cloud";
-    const url = `${gateway}/ipfs/${cid}`;
+    const url = new URL(`/ipfs/${encodeURIComponent(cid)}`, gateway).toString();
     const res = await fetch(url, { method: "GET" });
     if (!res.ok) {
       console.warn("[superfluid-points] IPFS fetch failed", {

--- a/apps/web/app/api/superfluid-points/leaderboard/route.ts
+++ b/apps/web/app/api/superfluid-points/leaderboard/route.ts
@@ -2,6 +2,7 @@ import pinataSDK from "@pinata/sdk";
 import { NextResponse } from "next/server";
 import { createClient, fetchExchange, gql } from "urql";
 import { chainConfigMap } from "@/configs/chains";
+import { isValidCid, buildIpfsUrl } from "@/utils/ipfs";
 
 const PINATA_POINTS_SNAPSHOT_NAME = "superfluid-activity-points";
 const PINATA_POINTS_SNAPSHOT_CID =
@@ -17,11 +18,6 @@ const normalizeGateway = (gw?: string | null) => {
   return `https://${trimmed}`;
 };
 
-const isValidCid = (value: string): boolean => {
-  const cid = value.trim();
-  // Allow common CIDv0/CIDv1 textual forms only (base58btc/base32 lowercase chars).
-  return /^[A-Za-z0-9]{46,120}$/.test(cid);
-};
 const IPFS_GATEWAY = normalizeGateway(process.env.IPFS_GATEWAY);
 
 const PINATA_JWT = process.env.PINATA_JWT;
@@ -48,7 +44,7 @@ const pinataClient =
 const fetchIpfsJson = async <T = any>(cid: string): Promise<T | null> => {
   if (!cid || !isValidCid(cid)) return null;
   try {
-    const ipfsUrl = new URL(`/ipfs/${encodeURIComponent(cid)}`, IPFS_GATEWAY).toString();
+    const ipfsUrl = buildIpfsUrl(IPFS_GATEWAY, cid);
     const res = await fetch(ipfsUrl);
     if (!res.ok) {
       console.warn("[leaderboard] ipfs fetch failed", {

--- a/apps/web/app/api/superfluid-points/leaderboard/route.ts
+++ b/apps/web/app/api/superfluid-points/leaderboard/route.ts
@@ -16,6 +16,12 @@ const normalizeGateway = (gw?: string | null) => {
   // Assume https if protocol omitted
   return `https://${trimmed}`;
 };
+
+const isValidCid = (value: string): boolean => {
+  const cid = value.trim();
+  // Allow common CIDv0/CIDv1 textual forms only (base58btc/base32 lowercase chars).
+  return /^[A-Za-z0-9]{46,120}$/.test(cid);
+};
 const IPFS_GATEWAY = normalizeGateway(process.env.IPFS_GATEWAY);
 
 const PINATA_JWT = process.env.PINATA_JWT;
@@ -40,9 +46,10 @@ const pinataClient =
   : null;
 
 const fetchIpfsJson = async <T = any>(cid: string): Promise<T | null> => {
-  if (!cid) return null;
+  if (!cid || !isValidCid(cid)) return null;
   try {
-    const res = await fetch(`${IPFS_GATEWAY}/ipfs/${cid}`);
+    const ipfsUrl = new URL(`/ipfs/${encodeURIComponent(cid)}`, IPFS_GATEWAY).toString();
+    const res = await fetch(ipfsUrl);
     if (!res.ok) {
       console.warn("[leaderboard] ipfs fetch failed", {
         cid,
@@ -205,6 +212,12 @@ export async function GET(request: Request) {
       campaignIdFromQuery ?
         `${PINATA_POINTS_SNAPSHOT_NAME}-${campaignIdFromQuery}`
       : PINATA_POINTS_SNAPSHOT_NAME;
+    if (cidFromQuery && !isValidCid(cidFromQuery)) {
+      return NextResponse.json(
+        { error: "Invalid cid parameter" },
+        { status: 400 },
+      );
+    }
     const cid =
       cidFromQuery ??
       (campaignIdFromQuery ? null : PINATA_POINTS_SNAPSHOT_CID) ??

--- a/apps/web/app/api/superfluid-points/route.ts
+++ b/apps/web/app/api/superfluid-points/route.ts
@@ -14,6 +14,7 @@ import {
 import { erc20ABI } from "@/src/generated";
 import { ChainId } from "@/types";
 import { getViemChain } from "@/utils/web3";
+import { isValidCid } from "@/utils/ipfs";
 
 type Strategy = {
   id: Address;
@@ -714,15 +715,12 @@ const pinataClient =
 const CAN_WRITE_PINATA = Boolean(pinataClient);
 
 const getIpfsGatewayUrl = (cid: string) => {
-  const gateway = IPFS_GATEWAY?.replace(/\/$/, "");
-  if (!gateway) {
-    return `https://gateway.pinata.cloud/ipfs/${cid}`;
+  const gateway = IPFS_GATEWAY ?? "https://gateway.pinata.cloud";
+  const url = new URL(`/ipfs/${encodeURIComponent(cid)}`, gateway);
+  if (PINATA_KEY) {
+    url.searchParams.set("pinataGatewayToken", PINATA_KEY);
   }
-
-  const gatewayToken =
-    PINATA_KEY ? `?pinataGatewayToken=${PINATA_KEY}` : "";
-
-  return `${gateway}/ipfs/${cid}${gatewayToken}`;
+  return url.toString();
 };
 const SKIP_IDENTITY_RESOLUTION =
   (process.env.SUPERFLUID_SKIP_IDENTITY_RESOLUTION ?? "").toLowerCase() ===
@@ -1187,7 +1185,7 @@ const ensureLatestTransferCacheCid = async (): Promise<string | null> => {
 const fetchIpfsJson = async (
   cid: string,
 ): Promise<{ entries?: Record<string, string | null> } | null> => {
-  if (!cid) return null;
+  if (!cid || !isValidCid(cid)) return null;
   try {
     const url = getIpfsGatewayUrl(cid);
     const res = await fetch(url, { method: "GET" });

--- a/apps/web/utils/ipfs.ts
+++ b/apps/web/utils/ipfs.ts
@@ -1,0 +1,20 @@
+/**
+ * Returns true when `value` is a plausible IPFS CID string.
+ * The pattern is intentionally broad to cover both CIDv0 (base58btc, ~46 chars)
+ * and CIDv1 (base32/base64url, 59+ chars) without being overly restrictive.
+ * It rejects any value containing path separators, whitespace, or other
+ * characters that could enable path-traversal / SSRF when building URLs.
+ */
+export const isValidCid = (value: string): boolean => {
+  const cid = value.trim();
+  // Broad alphanumeric allowlist that covers CIDv0 (base58btc) and CIDv1 (base32/base64url).
+  return /^[A-Za-z0-9]{46,120}$/.test(cid);
+};
+
+/**
+ * Builds a safe IPFS gateway URL for the given CID.
+ * Uses `new URL()` + `encodeURIComponent` to avoid path-shaping issues.
+ */
+export const buildIpfsUrl = (gateway: string, cid: string): string => {
+  return new URL(`/ipfs/${encodeURIComponent(cid)}`, gateway).toString();
+};


### PR DESCRIPTION
Potential fix for [https://github.com/1Hive/gardens-v2/security/code-scanning/19](https://github.com/1Hive/gardens-v2/security/code-scanning/19)

To fix this without changing intended functionality, validate `cid` against a strict allowlist format before using it in the outgoing request URL. Since a CID should only contain specific characters, reject any value outside that character set and length range. Then build the request URL using `new URL()` and `encodeURIComponent(cid)` to avoid path-shaping issues.

Best concrete fix in `apps/web/app/api/superfluid-points-gd/leaderboard/route.ts`:
- Add a CID validator helper (string trim + regex allowlist).
- In `GET`, validate `cidFromQuery`; if invalid, return `400`.
- In `fetchIpfsJson`, defensively validate `cid` again and abort if invalid.
- Replace string interpolation URL construction with `new URL(`/ipfs/${encodeURIComponent(cid)}`, IPFS_GATEWAY).toString()`.

This preserves behavior for valid CIDs and blocks malicious/path-manipulating inputs.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
