### PR TITLE
Skip no-op streaming rebalances

### DIFF
--- a/apps/web/app/api/rebalance-keeper/[chain]/rebalanceDecision.test.ts
+++ b/apps/web/app/api/rebalance-keeper/[chain]/rebalanceDecision.test.ts
@@ -1,0 +1,249 @@
+import { describe, expect, it } from "vitest";
+import {
+  ACTIVE_STATUS,
+  DISPUTED_STATUS,
+  RebalanceDecisionInput,
+  evaluateRebalanceDecision,
+  isSignificantRateChange,
+  safeEvaluateRebalanceDecision,
+} from "./rebalanceDecision";
+
+const baseInput = (
+  overrides: Partial<RebalanceDecisionInput> = {},
+): RebalanceDecisionInput => ({
+  isStrategyEnabled: true,
+  proposalCount: 1,
+  poolAmount: 1_000_000n,
+  totalPointsActivated: 1_000n,
+  decay: 9_000_000n,
+  threshold: 100n,
+  streamingRatePerSecond: 1_000n,
+  superTokenBalance: 10_000n,
+  currentTotalFlowRate: 0n,
+  hasStreamingConfig: true,
+  thresholdBps: 50n,
+  proposals: [
+    {
+      status: ACTIVE_STATUS,
+      conviction: 500n,
+      currentUnits: 0n,
+      currentFlowRate: 0n,
+      hasEscrow: true,
+    },
+  ],
+  ...overrides,
+});
+
+describe("rebalance decision", () => {
+  it("runs when a proposal creates a significant stream rate change", () => {
+    expect(evaluateRebalanceDecision(baseInput())).toEqual({
+      shouldRun: true,
+      reason: "significant_rate_change_50bps",
+    });
+  });
+
+  it("skips when max conviction already streams the full monthly budget", () => {
+    expect(
+      evaluateRebalanceDecision(
+        baseInput({
+          currentTotalFlowRate: 1_000n,
+          proposals: [
+            {
+              status: ACTIVE_STATUS,
+              conviction: 15_000n,
+              currentUnits: 1_000n,
+              currentFlowRate: 1_000n,
+              hasEscrow: true,
+            },
+          ],
+        }),
+      ),
+    ).toEqual({
+      shouldRun: false,
+      reason: "insignificant_rate_change_50bps",
+    });
+  });
+
+  it("skips proposal allocation drift below the configured rate threshold", () => {
+    expect(
+      evaluateRebalanceDecision(
+        baseInput({
+          currentTotalFlowRate: 100n,
+          streamingRatePerSecond: 1_000n,
+          proposals: [
+            {
+              status: ACTIVE_STATUS,
+              conviction: 500n,
+              currentUnits: 50n,
+              currentFlowRate: 50n,
+              hasEscrow: true,
+            },
+            {
+              status: DISPUTED_STATUS,
+              conviction: 500n,
+              currentUnits: 50n,
+              currentFlowRate: 50n,
+              hasEscrow: true,
+            },
+          ],
+        }),
+      ),
+    ).toEqual({
+      shouldRun: false,
+      reason: "insignificant_rate_change_50bps",
+    });
+  });
+
+  it("runs when proposal allocation drift exceeds the rate threshold", () => {
+    expect(
+      evaluateRebalanceDecision(
+        baseInput({
+          currentTotalFlowRate: 100n,
+          proposals: [
+            {
+              status: ACTIVE_STATUS,
+              conviction: 600n,
+              currentUnits: 50n,
+              currentFlowRate: 50n,
+              hasEscrow: true,
+            },
+            {
+              status: ACTIVE_STATUS,
+              conviction: 400n,
+              currentUnits: 50n,
+              currentFlowRate: 50n,
+              hasEscrow: true,
+            },
+          ],
+        }),
+      ),
+    ).toEqual({
+      shouldRun: true,
+      reason: "significant_rate_change_50bps",
+    });
+  });
+
+  it("skips when all active proposals are below threshold and flow is already stopped", () => {
+    expect(
+      evaluateRebalanceDecision(
+        baseInput({
+          proposals: [
+            {
+              status: ACTIVE_STATUS,
+              conviction: 100n,
+              currentUnits: 0n,
+              currentFlowRate: 0n,
+              hasEscrow: true,
+            },
+          ],
+        }),
+      ),
+    ).toEqual({
+      shouldRun: false,
+      reason: "all_proposals_below_threshold",
+    });
+  });
+
+  it("skips empty pools with no active flow", () => {
+    expect(
+      evaluateRebalanceDecision(
+        baseInput({
+          poolAmount: 0n,
+          currentTotalFlowRate: 0n,
+        }),
+      ),
+    ).toEqual({
+      shouldRun: false,
+      reason: "pool_empty_zero_flow",
+    });
+  });
+
+  it("skips when there are no proposals and no active flow", () => {
+    expect(
+      evaluateRebalanceDecision(
+        baseInput({
+          proposalCount: 0,
+          proposals: [],
+        }),
+      ),
+    ).toEqual({
+      shouldRun: false,
+      reason: "no_proposals",
+    });
+  });
+
+  it("runs to stop flow when there are no proposals but flow is still active", () => {
+    expect(
+      evaluateRebalanceDecision(
+        baseInput({
+          proposalCount: 0,
+          currentTotalFlowRate: 1n,
+          proposals: [],
+        }),
+      ),
+    ).toEqual({
+      shouldRun: true,
+      reason: "no_proposals_stop_flow",
+    });
+  });
+
+  it("runs to clear units from inactive proposals", () => {
+    expect(
+      evaluateRebalanceDecision(
+        baseInput({
+          currentTotalFlowRate: 0n,
+          proposals: [
+            {
+              status: 4,
+              conviction: 500n,
+              currentUnits: 10n,
+              currentFlowRate: 0n,
+              hasEscrow: true,
+            },
+          ],
+        }),
+      ),
+    ).toEqual({
+      shouldRun: true,
+      reason: "inactive_proposal_units_need_clear",
+    });
+  });
+
+  it("falls back to rebalancing when the decision algorithm throws", () => {
+    const errors: unknown[] = [];
+
+    expect(
+      safeEvaluateRebalanceDecision(
+        {
+          ...baseInput(),
+          proposals: null,
+        } as unknown as RebalanceDecisionInput,
+        (error) => errors.push(error),
+      ),
+    ).toEqual({
+      shouldRun: true,
+      reason: "decision_failed_safe_rebalance",
+      error: "Cannot read properties of null (reading 'filter')",
+    });
+    expect(errors).toHaveLength(1);
+  });
+});
+
+describe("rate significance threshold", () => {
+  it("treats 50 bps as the default materiality boundary", () => {
+    expect(
+      isSignificantRateChange({
+        current: 10_000n,
+        target: 10_050n,
+        thresholdBps: 50n,
+      }),
+    ).toBe(false);
+    expect(
+      isSignificantRateChange({
+        current: 10_000n,
+        target: 10_051n,
+        thresholdBps: 50n,
+      }),
+    ).toBe(true);
+  });
+});

--- a/apps/web/app/api/rebalance-keeper/[chain]/rebalanceDecision.ts
+++ b/apps/web/app/api/rebalance-keeper/[chain]/rebalanceDecision.ts
@@ -1,0 +1,216 @@
+export const ACTIVE_STATUS = 1;
+export const DISPUTED_STATUS = 5;
+export const CONVICTION_D = 10_000_000n;
+export const UINT128_MAX = (1n << 128n) - 1n;
+export const DEFAULT_SIGNIFICANT_RATE_CHANGE_BPS = 50n;
+
+export type RebalanceDecisionInput = {
+  isStrategyEnabled: boolean;
+  proposalCount: number;
+  poolAmount: bigint;
+  totalPointsActivated: bigint;
+  decay: bigint;
+  threshold: bigint;
+  streamingRatePerSecond: bigint;
+  superTokenBalance: bigint;
+  currentTotalFlowRate: bigint;
+  hasStreamingConfig: boolean;
+  thresholdBps?: bigint;
+  proposals: Array<{
+    status: number;
+    conviction: bigint;
+    currentUnits: bigint;
+    currentFlowRate: bigint;
+    hasEscrow: boolean;
+  }>;
+};
+
+export type RebalanceDecision = {
+  shouldRun: boolean;
+  reason: string;
+  error?: string;
+};
+
+const absDiff = (a: bigint, b: bigint) => (a > b ? a - b : b - a);
+
+export const isSignificantRateChange = ({
+  current,
+  target,
+  thresholdBps,
+}: {
+  current: bigint;
+  target: bigint;
+  thresholdBps: bigint;
+}) => {
+  if (current === target) return false;
+  const diff = absDiff(current, target);
+  if (current === 0n || target === 0n) return diff > 0n;
+
+  const reference = current > target ? current : target;
+  const threshold = (reference * thresholdBps) / 10_000n;
+  return diff > (threshold > 0n ? threshold : 1n);
+};
+
+export function evaluateRebalanceDecision({
+  isStrategyEnabled,
+  proposalCount,
+  poolAmount,
+  totalPointsActivated,
+  decay,
+  threshold,
+  streamingRatePerSecond,
+  superTokenBalance,
+  currentTotalFlowRate,
+  hasStreamingConfig,
+  thresholdBps = DEFAULT_SIGNIFICANT_RATE_CHANGE_BPS,
+  proposals,
+}: RebalanceDecisionInput): RebalanceDecision {
+  if (!hasStreamingConfig) {
+    return { shouldRun: false, reason: "streaming_not_configured" };
+  }
+
+  if (!isStrategyEnabled) {
+    return currentTotalFlowRate === 0n ?
+        { shouldRun: false, reason: "strategy_disabled_zero_flow" }
+      : { shouldRun: true, reason: "strategy_disabled_stop_flow" };
+  }
+
+  if (proposalCount === 0) {
+    return currentTotalFlowRate === 0n ?
+        { shouldRun: false, reason: "no_proposals" }
+      : { shouldRun: true, reason: "no_proposals_stop_flow" };
+  }
+
+  if (poolAmount === 0n && currentTotalFlowRate === 0n) {
+    return { shouldRun: false, reason: "pool_empty_zero_flow" };
+  }
+
+  const maxConviction =
+    decay >= CONVICTION_D ? 0n : (
+      (totalPointsActivated * CONVICTION_D) / (CONVICTION_D - decay)
+    );
+
+  let totalEligibleConviction = 0n;
+  let activeOrDisputedWithEscrow = 0;
+  let nonActiveUnitsNeedClearing = false;
+
+  const activeProposals = proposals.filter((proposal) => {
+    if (!proposal.hasEscrow) return false;
+    const isActiveOrDisputed =
+      proposal.status === ACTIVE_STATUS || proposal.status === DISPUTED_STATUS;
+    if (!isActiveOrDisputed) {
+      if (proposal.currentUnits !== 0n) {
+        nonActiveUnitsNeedClearing = true;
+      }
+      return false;
+    }
+
+    activeOrDisputedWithEscrow += 1;
+    if (proposal.conviction > threshold) {
+      totalEligibleConviction += proposal.conviction;
+    }
+    return true;
+  });
+
+  if (nonActiveUnitsNeedClearing) {
+    return { shouldRun: true, reason: "inactive_proposal_units_need_clear" };
+  }
+
+  const canStartStream =
+    superTokenBalance > 0n &&
+    streamingRatePerSecond > 0n &&
+    maxConviction > 0n &&
+    totalEligibleConviction > 0n;
+
+  const clampedConviction =
+    totalEligibleConviction > maxConviction ? maxConviction : (
+      totalEligibleConviction
+    );
+  const targetTotalFlowRate =
+    canStartStream ?
+      (streamingRatePerSecond * clampedConviction) / maxConviction
+    : 0n;
+  const streamingUnitBudget =
+    targetTotalFlowRate > UINT128_MAX ? UINT128_MAX : targetTotalFlowRate;
+
+  let targetTotalUnits = 0n;
+  const targetUnitsByIndex = activeProposals.map((proposal) => {
+    let units = 0n;
+    if (proposal.conviction > threshold) {
+      if (canStartStream) {
+        units =
+          (proposal.conviction * streamingUnitBudget) / totalEligibleConviction;
+        if (units === 0n) units = 1n;
+      } else {
+        units = proposal.conviction / CONVICTION_D;
+      }
+    }
+    if (units > UINT128_MAX) units = UINT128_MAX;
+    targetTotalUnits += units;
+    return units;
+  });
+
+  const hasSignificantPoolRateChange = isSignificantRateChange({
+    current: currentTotalFlowRate,
+    target: targetTotalFlowRate,
+    thresholdBps,
+  });
+
+  const hasSignificantProposalRateChange = activeProposals.some(
+    (proposal, index) => {
+      const targetUnits = targetUnitsByIndex[index] ?? 0n;
+      const targetFlowRate =
+        targetTotalUnits > 0n ?
+          (targetTotalFlowRate * targetUnits) / targetTotalUnits
+        : 0n;
+      return isSignificantRateChange({
+        current: proposal.currentFlowRate,
+        target: targetFlowRate,
+        thresholdBps,
+      });
+    },
+  );
+
+  if (hasSignificantPoolRateChange || hasSignificantProposalRateChange) {
+    return {
+      shouldRun: true,
+      reason: `significant_rate_change_${thresholdBps}bps`,
+    };
+  }
+
+  for (let i = 0; i < activeProposals.length; i++) {
+    const targetUnits = targetUnitsByIndex[i] ?? 0n;
+    if (targetUnits === 0n && activeProposals[i]?.currentUnits !== 0n) {
+      return { shouldRun: true, reason: "proposal_units_need_zeroing" };
+    }
+  }
+
+  if (activeOrDisputedWithEscrow === 0) {
+    return { shouldRun: false, reason: "no_active_or_disputed_proposals" };
+  }
+
+  if (totalEligibleConviction === 0n && currentTotalFlowRate === 0n) {
+    return { shouldRun: false, reason: "all_proposals_below_threshold" };
+  }
+
+  return {
+    shouldRun: false,
+    reason: `insignificant_rate_change_${thresholdBps}bps`,
+  };
+}
+
+export function safeEvaluateRebalanceDecision(
+  input: RebalanceDecisionInput,
+  onError?: (error: unknown) => void,
+): RebalanceDecision {
+  try {
+    return evaluateRebalanceDecision(input);
+  } catch (error) {
+    onError?.(error);
+    return {
+      shouldRun: true,
+      reason: "decision_failed_safe_rebalance",
+      error: error instanceof Error ? error.message : "unknown_error",
+    };
+  }
+}

--- a/apps/web/app/api/rebalance-keeper/[chain]/route.ts
+++ b/apps/web/app/api/rebalance-keeper/[chain]/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import {
   Address,
+  PublicClient,
   createPublicClient,
   createWalletClient,
   http,
@@ -8,6 +9,12 @@ import {
   parseAbi,
 } from "viem";
 import { privateKeyToAccount } from "viem/accounts";
+import {
+  ACTIVE_STATUS,
+  DEFAULT_SIGNIFICANT_RATE_CHANGE_BPS,
+  DISPUTED_STATUS,
+  safeEvaluateRebalanceDecision,
+} from "./rebalanceDecision";
 import { chainConfigMap, getConfigByChain } from "@/configs/chains";
 import { getGasTokenUsdPrice } from "@/services/coingecko";
 import { ChainId } from "@/types";
@@ -21,10 +28,24 @@ type Params = {
 
 type StrategyCandidate = {
   id: string;
+  metadata?: {
+    title?: string | null;
+  } | null;
+  registryCommunity?: {
+    id?: string | null;
+    communityName?: string | null;
+  } | null;
   config?: {
     proposalType?: string | number | null;
   } | null;
   proposals?: Array<{ id: string }> | null;
+};
+
+type SelectedStrategyCandidate = {
+  address: Address;
+  title: string | null;
+  communityAddress: Address | null;
+  communityTitle: string | null;
 };
 
 type ChainRunResult = {
@@ -33,6 +54,12 @@ type ChainRunResult = {
   gasCostUsdTotal: number;
   sent: Array<{
     strategy: Address;
+    title?: string | null;
+    communityAddress?: Address | null;
+    communityTitle?: string | null;
+    uri?: string | null;
+    rebalanceReason?: string;
+    rebalanceError?: string;
     txHash: `0x${string}`;
     gasUsed: string;
     effectiveGasPrice?: string;
@@ -41,7 +68,15 @@ type ChainRunResult = {
     gasTokenUsdPrice?: number;
     gasCostUsd?: number;
   }>;
-  skipped: Array<{ strategy: Address; reason: string }>;
+  skipped: Array<{
+    strategy: Address;
+    title?: string | null;
+    communityAddress?: Address | null;
+    communityTitle?: string | null;
+    uri?: string | null;
+    rebalanceError?: string;
+    reason: string;
+  }>;
   error?: string;
 };
 
@@ -53,18 +88,39 @@ const REBALANCE_KEEPER_ABI = parseAbi([
   "function lastRebalanceAt() view returns (uint256)",
   "function rebalanceCooldown() view returns (uint256)",
   "function isAuthorizedRebalanceCaller(address) view returns (bool)",
+  "function proposalCounter() view returns (uint256)",
+  "function getPoolAmount() view returns (uint256)",
+  "function totalPointsActivated() view returns (uint256)",
+  "function cvParams() view returns (uint256 maxRatio, uint256 weight, uint256 decay, uint256 minThresholdPoints)",
+  "function calculateThreshold(uint256 requestedAmount) view returns (uint256)",
+  "function calculateProposalConviction(uint256 proposalId) view returns (uint256)",
+  "function getProposal(uint256 proposalId) view returns (address submitter, address beneficiary, address requestedToken, uint256 requestedAmount, uint256 stakedAmount, uint8 proposalStatus, uint256 blockLast, uint256 convictionLast, uint256 threshold, uint256 voterStakedPoints, uint256 arbitrableConfigVersion, uint256 protocol)",
+  "function streamingEscrow(uint256 proposalId) view returns (address)",
+  "function streamingRatePerSecond() view returns (uint256)",
+  "function superfluidToken() view returns (address)",
+  "function superfluidGDA() view returns (address)",
   "error UnauthorizedRebalanceCaller(address caller)",
   "error RebalanceCooldownActive(uint256 secondsRemaining)",
 ]);
 
+const SUPER_TOKEN_ABI = parseAbi([
+  "function balanceOf(address account) view returns (uint256)",
+]);
+
+const SUPERFLUID_POOL_ABI = parseAbi([
+  "function getTotalFlowRate() view returns (int96)",
+  "function getUnits(address memberAddr) view returns (uint128)",
+  "function getMemberFlowRate(address memberAddr) view returns (int96)",
+]);
+
 const STRATEGY_PAGE_SIZE = 500;
 const STREAMING_PROPOSAL_TYPE = 2;
-const ACTIVE_STATUS = 1;
-const DISPUTED_STATUS = 5;
 const USD_PRECISION = 6;
 const USD_PRECISION_MULTIPLIER = 10 ** USD_PRECISION;
 const WEI_PER_NATIVE_TOKEN = 10n ** 18n;
 const REBALANCE_KEEPER_EXCLUDED_CHAIN_IDS = new Set<number>([421614]);
+const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
+const GARDENS_APP_BASE_URL = "https://app.gardens.fund";
 
 const roundToUsdPrecision = (value: number) =>
   Math.round(value * USD_PRECISION_MULTIPLIER) / USD_PRECISION_MULTIPLIER;
@@ -86,6 +142,277 @@ const calculateGasCostUsd = ({
   return Number(gasCostUsdScaled) / USD_PRECISION_MULTIPLIER;
 };
 
+const normalizeTitle = (title: string | null | undefined) => {
+  const trimmed = title?.trim();
+  return trimmed === "" ? null : trimmed ?? null;
+};
+
+const buildGardenUri = ({
+  chainId,
+  communityAddress,
+  strategyAddress,
+}: {
+  chainId: number | string;
+  communityAddress: Address | null;
+  strategyAddress: Address;
+}) =>
+  communityAddress == null ?
+    null
+  : `${GARDENS_APP_BASE_URL}/gardens/${chainId}/${communityAddress}/${strategyAddress}`;
+
+const readBigintEnv = (key: string, fallback: bigint) => {
+  const raw = process.env[key];
+  if (raw == null || raw.trim() === "") return fallback;
+  try {
+    const parsed = BigInt(raw);
+    return parsed >= 0n ? parsed : fallback;
+  } catch {
+    return fallback;
+  }
+};
+
+const getCvParam = (
+  cvParams: unknown,
+  index: number,
+  key: "maxRatio" | "weight" | "decay" | "minThresholdPoints",
+) => {
+  const tuple = cvParams as Record<string, unknown> & Array<unknown>;
+  return BigInt((tuple[key] ?? tuple[index] ?? 0) as bigint | number | string);
+};
+
+const getProposalStatus = (proposal: unknown) => {
+  const tuple = proposal as Record<string, unknown> & Array<unknown>;
+  return Number(tuple.proposalStatus ?? tuple[5] ?? -1);
+};
+
+async function readOptionalBigInt({
+  publicClient,
+  address,
+  abi,
+  functionName,
+  args,
+}: {
+  publicClient: PublicClient;
+  address: Address;
+  abi: typeof SUPER_TOKEN_ABI | typeof SUPERFLUID_POOL_ABI;
+  functionName: string;
+  args?: readonly unknown[];
+}) {
+  try {
+    const result = await publicClient.readContract({
+      address,
+      abi,
+      functionName,
+      args,
+    } as any);
+    return BigInt(result as bigint);
+  } catch {
+    return undefined;
+  }
+}
+
+async function shouldRunRebalance({
+  publicClient,
+  strategy,
+}: {
+  publicClient: PublicClient;
+  strategy: Address;
+}): Promise<{ shouldRun: boolean; reason?: string; error?: string }> {
+  const thresholdBps = readBigintEnv(
+    "STREAMING_REBALANCE_SIGNIFICANT_RATE_CHANGE_BPS",
+    DEFAULT_SIGNIFICANT_RATE_CHANGE_BPS,
+  );
+
+  try {
+    const [
+      proposalCounter,
+      poolAmount,
+      totalPointsActivated,
+      cvParams,
+      threshold,
+      streamingRatePerSecond,
+      superfluidToken,
+      superfluidGDA,
+    ] = await Promise.all([
+      publicClient.readContract({
+        address: strategy,
+        abi: REBALANCE_KEEPER_ABI,
+        functionName: "proposalCounter",
+      }),
+      publicClient.readContract({
+        address: strategy,
+        abi: REBALANCE_KEEPER_ABI,
+        functionName: "getPoolAmount",
+      }),
+      publicClient.readContract({
+        address: strategy,
+        abi: REBALANCE_KEEPER_ABI,
+        functionName: "totalPointsActivated",
+      }),
+      publicClient.readContract({
+        address: strategy,
+        abi: REBALANCE_KEEPER_ABI,
+        functionName: "cvParams",
+      }),
+      publicClient.readContract({
+        address: strategy,
+        abi: REBALANCE_KEEPER_ABI,
+        functionName: "calculateThreshold",
+        args: [0n],
+      }),
+      publicClient.readContract({
+        address: strategy,
+        abi: REBALANCE_KEEPER_ABI,
+        functionName: "streamingRatePerSecond",
+      }),
+      publicClient.readContract({
+        address: strategy,
+        abi: REBALANCE_KEEPER_ABI,
+        functionName: "superfluidToken",
+      }),
+      publicClient.readContract({
+        address: strategy,
+        abi: REBALANCE_KEEPER_ABI,
+        functionName: "superfluidGDA",
+      }),
+    ]);
+
+    const superTokenAddress = superfluidToken as Address;
+    const gdaAddress = superfluidGDA as Address;
+    if (superTokenAddress === ZERO_ADDRESS || gdaAddress === ZERO_ADDRESS) {
+      return { shouldRun: false, reason: "streaming_not_configured" };
+    }
+
+    const currentTotalFlowRate =
+      (await readOptionalBigInt({
+        publicClient,
+        address: gdaAddress,
+        abi: SUPERFLUID_POOL_ABI,
+        functionName: "getTotalFlowRate",
+      })) ?? 0n;
+
+    const proposalCount = Number(proposalCounter);
+    if (proposalCount === 0) {
+      return currentTotalFlowRate === 0n ?
+          { shouldRun: false, reason: "no_proposals" }
+        : { shouldRun: true, reason: "no_proposals_stop_flow" };
+    }
+
+    if (BigInt(poolAmount) === 0n && currentTotalFlowRate === 0n) {
+      return { shouldRun: false, reason: "pool_empty_zero_flow" };
+    }
+
+    const superTokenBalance =
+      (await readOptionalBigInt({
+        publicClient,
+        address: superTokenAddress,
+        abi: SUPER_TOKEN_ABI,
+        functionName: "balanceOf",
+        args: [strategy],
+      })) ?? 0n;
+
+    const decay = getCvParam(cvParams, 2, "decay");
+    const proposals: Array<{
+      escrow: Address;
+      status: number;
+      conviction: bigint;
+      currentUnits: bigint;
+      currentFlowRate: bigint;
+    }> = [];
+
+    for (let id = 1; id <= proposalCount; id++) {
+      const [proposal, escrowAddress] = await Promise.all([
+        publicClient.readContract({
+          address: strategy,
+          abi: REBALANCE_KEEPER_ABI,
+          functionName: "getProposal",
+          args: [BigInt(id)],
+        }),
+        publicClient.readContract({
+          address: strategy,
+          abi: REBALANCE_KEEPER_ABI,
+          functionName: "streamingEscrow",
+          args: [BigInt(id)],
+        }),
+      ]);
+      const escrow = escrowAddress as Address;
+      if (escrow === ZERO_ADDRESS) continue;
+
+      const [conviction, currentUnits, currentFlowRate] = await Promise.all([
+        publicClient.readContract({
+          address: strategy,
+          abi: REBALANCE_KEEPER_ABI,
+          functionName: "calculateProposalConviction",
+          args: [BigInt(id)],
+        }),
+        readOptionalBigInt({
+          publicClient,
+          address: gdaAddress,
+          abi: SUPERFLUID_POOL_ABI,
+          functionName: "getUnits",
+          args: [escrow],
+        }),
+        readOptionalBigInt({
+          publicClient,
+          address: gdaAddress,
+          abi: SUPERFLUID_POOL_ABI,
+          functionName: "getMemberFlowRate",
+          args: [escrow],
+        }),
+      ]);
+
+      const status = getProposalStatus(proposal);
+      const convictionValue = BigInt(conviction);
+
+      proposals.push({
+        escrow,
+        status,
+        conviction: convictionValue,
+        currentUnits: currentUnits ?? 0n,
+        currentFlowRate: currentFlowRate ?? 0n,
+      });
+    }
+
+    return safeEvaluateRebalanceDecision(
+      {
+        // Candidate discovery already filters enabled strategies. The internal
+        // _isStrategyEnabled selector is not exposed on every strategy diamond.
+        isStrategyEnabled: true,
+        proposalCount,
+        poolAmount: BigInt(poolAmount),
+        totalPointsActivated: BigInt(totalPointsActivated),
+        decay,
+        threshold: BigInt(threshold),
+        streamingRatePerSecond: BigInt(streamingRatePerSecond),
+        superTokenBalance,
+        currentTotalFlowRate,
+        hasStreamingConfig: true,
+        thresholdBps,
+        proposals: proposals.map((proposal) => ({
+          status: proposal.status,
+          conviction: proposal.conviction,
+          currentUnits: proposal.currentUnits,
+          currentFlowRate: proposal.currentFlowRate,
+          hasEscrow: true,
+        })),
+      },
+      (error) => {
+        console.warn("rebalance-keeper: decision failed, rebalancing safely", {
+          strategy,
+          error: error instanceof Error ? error.message : "unknown_error",
+        });
+      },
+    );
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "unknown_error";
+    console.warn("rebalance-keeper: preflight failed, falling back to simulate", {
+      strategy,
+      error: message,
+    });
+    return { shouldRun: true, reason: "preflight_failed", error: message };
+  }
+}
+
 const STRATEGY_QUERY = `
   query RebalanceCandidates($first: Int!, $skip: Int!) {
     cvstrategies(
@@ -94,6 +421,13 @@ const STRATEGY_QUERY = `
       where: { isEnabled: true, archived: false }
     ) {
       id
+      metadata {
+        title
+      }
+      registryCommunity {
+        id
+        communityName
+      }
       config {
         proposalType
       }
@@ -137,9 +471,9 @@ async function querySubgraph<T>(
 async function fetchStrategyCandidates(
   primaryUrl: string,
   fallbackUrl?: string,
-): Promise<Address[]> {
+): Promise<SelectedStrategyCandidate[]> {
   let skip = 0;
-  const selected: Address[] = [];
+  const selected = new Map<string, SelectedStrategyCandidate>();
 
   // Retry the same page on fallback if primary fails.
   const fetchPage = async (offset: number) => {
@@ -173,7 +507,20 @@ async function fetchStrategyCandidates(
         hasActiveOrDisputed &&
         isAddress(strategy.id)
       ) {
-        selected.push(strategy.id as Address);
+        const address = strategy.id.toLowerCase() as Address;
+        const communityAddress =
+          strategy.registryCommunity?.id != null &&
+          isAddress(strategy.registryCommunity.id) ?
+            (strategy.registryCommunity.id.toLowerCase() as Address)
+          : null;
+        selected.set(address, {
+          address,
+          title: normalizeTitle(strategy.metadata?.title),
+          communityAddress,
+          communityTitle: normalizeTitle(
+            strategy.registryCommunity?.communityName,
+          ),
+        });
       }
     }
 
@@ -181,9 +528,7 @@ async function fetchStrategyCandidates(
     skip += STRATEGY_PAGE_SIZE;
   }
 
-  return Array.from(new Set(selected.map((x) => x.toLowerCase()))).map(
-    (x) => x as Address,
-  );
+  return Array.from(selected.values());
 }
 
 async function runKeeperForChain({
@@ -245,29 +590,52 @@ async function runKeeperForChain({
     const block = await publicClient.getBlock({ blockTag: "latest" });
     const now = Number(block.timestamp);
     const sent: ConfirmedRebalanceTx[] = [];
-    const skipped: Array<{ strategy: Address; reason: string }> = [];
+    const skipped: ChainRunResult["skipped"] = [];
     let gasCostUsdTotal = 0;
     const gasTokenSymbol = getViemChain(chainId).nativeCurrency.symbol;
     let gasTokenUsdPrice: number | undefined;
 
-    try {
-      gasTokenUsdPrice = await getGasTokenUsdPrice({
-        chainId: chainConfig.id,
-        symbol: gasTokenSymbol,
-      });
-    } catch (error) {
-      console.warn("rebalance-keeper: failed to fetch gas token usd price", {
+    if (!chainConfig.isTestnet) {
+      try {
+        gasTokenUsdPrice = await getGasTokenUsdPrice({
+          chainId: chainConfig.id,
+          symbol: gasTokenSymbol,
+        });
+      } catch (error) {
+        console.warn("rebalance-keeper: failed to fetch gas token usd price", {
+          chainId: chainConfig.id,
+          gasTokenSymbol,
+          impact: "rebalance will continue without USD gas cost enrichment",
+          error:
+            error instanceof Error ?
+              { name: error.name, message: error.message, stack: error.stack }
+            : error,
+        });
+      }
+    } else {
+      console.info("rebalance-keeper: skipping testnet gas USD enrichment", {
         chainId: chainConfig.id,
         gasTokenSymbol,
-        impact: "rebalance will continue without USD gas cost enrichment",
-        error:
-          error instanceof Error ?
-            { name: error.name, message: error.message, stack: error.stack }
-          : error,
       });
     }
 
-    for (const strategy of strategies) {
+    for (const strategyCandidate of strategies) {
+      const {
+        address: strategy,
+        title,
+        communityAddress,
+        communityTitle,
+      } = strategyCandidate;
+      const strategyResponseContext = {
+        title,
+        communityAddress,
+        communityTitle,
+        uri: buildGardenUri({
+          chainId: chainConfig.id,
+          communityAddress,
+          strategyAddress: strategy,
+        }),
+      };
       try {
         const proposalType = Number(
           await publicClient.readContract({
@@ -277,7 +645,11 @@ async function runKeeperForChain({
           }),
         );
         if (proposalType !== STREAMING_PROPOSAL_TYPE) {
-          skipped.push({ strategy, reason: "not_streaming_pool" });
+          skipped.push({
+            strategy,
+            ...strategyResponseContext,
+            reason: "not_streaming_pool",
+          });
           continue;
         }
 
@@ -290,6 +662,7 @@ async function runKeeperForChain({
         if (!isAuthorizedCaller) {
           skipped.push({
             strategy,
+            ...strategyResponseContext,
             reason: `unauthorized_rebalance_caller:${account.address}`,
           });
           continue;
@@ -311,7 +684,25 @@ async function runKeeperForChain({
         const nextRebalanceAt = Number(lastRebalanceAt) + Number(cooldown);
         const secondsLeft = nextRebalanceAt - now;
         if (Number(cooldown) > 0 && secondsLeft > minSecondsLeft) {
-          skipped.push({ strategy, reason: `cooldown_active_${secondsLeft}s` });
+          skipped.push({
+            strategy,
+            ...strategyResponseContext,
+            reason: `cooldown_active_${secondsLeft}s`,
+          });
+          continue;
+        }
+
+        const rebalanceNeed = await shouldRunRebalance({
+          publicClient,
+          strategy,
+        });
+        if (!rebalanceNeed.shouldRun) {
+          skipped.push({
+            strategy,
+            ...strategyResponseContext,
+            rebalanceError: rebalanceNeed.error,
+            reason: rebalanceNeed.reason ?? "rebalance_noop",
+          });
           continue;
         }
 
@@ -323,7 +714,12 @@ async function runKeeperForChain({
         });
 
         if (dryRun) {
-          skipped.push({ strategy, reason: "dry_run" });
+          skipped.push({
+            strategy,
+            ...strategyResponseContext,
+            rebalanceError: rebalanceNeed.error,
+            reason: "dry_run",
+          });
           continue;
         }
 
@@ -337,6 +733,9 @@ async function runKeeperForChain({
           : undefined;
         const confirmedTx: ConfirmedRebalanceTx = {
           strategy,
+          ...strategyResponseContext,
+          rebalanceReason: rebalanceNeed.reason,
+          rebalanceError: rebalanceNeed.error,
           txHash: hash,
           gasUsed,
           effectiveGasPrice,
@@ -386,7 +785,11 @@ async function runKeeperForChain({
           reason.includes("gas required exceeds allowance (0)") ?
             `${reason}\nHint: keeper ${account.address} has no native balance on chain ${chainConfig.id}. Fund this wallet to pay gas.`
           : reason;
-        skipped.push({ strategy, reason: normalizedReason });
+        skipped.push({
+          strategy,
+          ...strategyResponseContext,
+          reason: normalizedReason,
+        });
       }
     }
 

--- a/apps/web/app/api/rebalance-keeper/[chain]/route.ts
+++ b/apps/web/app/api/rebalance-keeper/[chain]/route.ts
@@ -121,6 +121,7 @@ const WEI_PER_NATIVE_TOKEN = 10n ** 18n;
 const REBALANCE_KEEPER_EXCLUDED_CHAIN_IDS = new Set<number>([421614]);
 const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
 const GARDENS_APP_BASE_URL = "https://app.gardens.fund";
+const PROPOSAL_MULTICALL_CHUNK_SIZE = 75;
 
 const roundToUsdPrecision = (value: number) =>
   Math.round(value * USD_PRECISION_MULTIPLIER) / USD_PRECISION_MULTIPLIER;
@@ -185,30 +186,51 @@ const getProposalStatus = (proposal: unknown) => {
   return Number(tuple.proposalStatus ?? tuple[5] ?? -1);
 };
 
-async function readOptionalBigInt({
+type MulticallResult = {
+  status: "success" | "failure";
+  result?: unknown;
+  error?: Error;
+};
+
+const requireMulticallResult = (result: MulticallResult, label: string) => {
+  if (result.status !== "success") {
+    throw new Error(`${label}_read_failed`);
+  }
+
+  return result.result;
+};
+
+const optionalMulticallBigInt = (result: MulticallResult) => {
+  if (result.status !== "success" || result.result == null) return undefined;
+  return BigInt(result.result as bigint);
+};
+
+async function multicallInChunks({
   publicClient,
-  address,
-  abi,
-  functionName,
-  args,
+  contracts,
+  chunkSize = PROPOSAL_MULTICALL_CHUNK_SIZE,
 }: {
   publicClient: PublicClient;
-  address: Address;
-  abi: typeof SUPER_TOKEN_ABI | typeof SUPERFLUID_POOL_ABI;
-  functionName: string;
-  args?: readonly unknown[];
+  contracts: Array<{
+    address: Address;
+    abi: typeof REBALANCE_KEEPER_ABI | typeof SUPER_TOKEN_ABI | typeof SUPERFLUID_POOL_ABI;
+    functionName: string;
+    args?: readonly unknown[];
+  }>;
+  chunkSize?: number;
 }) {
-  try {
-    const result = await publicClient.readContract({
-      address,
-      abi,
-      functionName,
-      args,
-    } as any);
-    return BigInt(result as bigint);
-  } catch {
-    return undefined;
+  const results: MulticallResult[] = [];
+
+  for (let index = 0; index < contracts.length; index += chunkSize) {
+    const chunk = contracts.slice(index, index + chunkSize);
+    const chunkResults = await publicClient.multicall({
+      allowFailure: true,
+      contracts: chunk as any,
+    });
+    results.push(...(chunkResults as MulticallResult[]));
   }
+
+  return results;
 }
 
 async function shouldRunRebalance({
@@ -224,58 +246,85 @@ async function shouldRunRebalance({
   );
 
   try {
+    const strategyReads = await publicClient.multicall({
+      allowFailure: true,
+      contracts: [
+        {
+          address: strategy,
+          abi: REBALANCE_KEEPER_ABI,
+          functionName: "proposalCounter",
+        },
+        {
+          address: strategy,
+          abi: REBALANCE_KEEPER_ABI,
+          functionName: "getPoolAmount",
+        },
+        {
+          address: strategy,
+          abi: REBALANCE_KEEPER_ABI,
+          functionName: "totalPointsActivated",
+        },
+        {
+          address: strategy,
+          abi: REBALANCE_KEEPER_ABI,
+          functionName: "cvParams",
+        },
+        {
+          address: strategy,
+          abi: REBALANCE_KEEPER_ABI,
+          functionName: "calculateThreshold",
+          args: [0n],
+        },
+        {
+          address: strategy,
+          abi: REBALANCE_KEEPER_ABI,
+          functionName: "streamingRatePerSecond",
+        },
+        {
+          address: strategy,
+          abi: REBALANCE_KEEPER_ABI,
+          functionName: "superfluidToken",
+        },
+        {
+          address: strategy,
+          abi: REBALANCE_KEEPER_ABI,
+          functionName: "superfluidGDA",
+        },
+      ] as const,
+    });
     const [
-      proposalCounter,
-      poolAmount,
-      totalPointsActivated,
-      cvParams,
-      threshold,
-      streamingRatePerSecond,
-      superfluidToken,
-      superfluidGDA,
-    ] = await Promise.all([
-      publicClient.readContract({
-        address: strategy,
-        abi: REBALANCE_KEEPER_ABI,
-        functionName: "proposalCounter",
-      }),
-      publicClient.readContract({
-        address: strategy,
-        abi: REBALANCE_KEEPER_ABI,
-        functionName: "getPoolAmount",
-      }),
-      publicClient.readContract({
-        address: strategy,
-        abi: REBALANCE_KEEPER_ABI,
-        functionName: "totalPointsActivated",
-      }),
-      publicClient.readContract({
-        address: strategy,
-        abi: REBALANCE_KEEPER_ABI,
-        functionName: "cvParams",
-      }),
-      publicClient.readContract({
-        address: strategy,
-        abi: REBALANCE_KEEPER_ABI,
-        functionName: "calculateThreshold",
-        args: [0n],
-      }),
-      publicClient.readContract({
-        address: strategy,
-        abi: REBALANCE_KEEPER_ABI,
-        functionName: "streamingRatePerSecond",
-      }),
-      publicClient.readContract({
-        address: strategy,
-        abi: REBALANCE_KEEPER_ABI,
-        functionName: "superfluidToken",
-      }),
-      publicClient.readContract({
-        address: strategy,
-        abi: REBALANCE_KEEPER_ABI,
-        functionName: "superfluidGDA",
-      }),
-    ]);
+      proposalCounterResult,
+      poolAmountResult,
+      totalPointsActivatedResult,
+      cvParamsResult,
+      thresholdResult,
+      streamingRatePerSecondResult,
+      superfluidTokenResult,
+      superfluidGDAResult,
+    ] = strategyReads as MulticallResult[];
+    const proposalCounter = requireMulticallResult(
+      proposalCounterResult,
+      "proposal_counter",
+    );
+    const poolAmount = requireMulticallResult(poolAmountResult, "pool_amount");
+    const totalPointsActivated = requireMulticallResult(
+      totalPointsActivatedResult,
+      "total_points_activated",
+    );
+    const cvParams = requireMulticallResult(cvParamsResult, "cv_params");
+    const threshold = requireMulticallResult(thresholdResult, "threshold");
+    const streamingRatePerSecond = requireMulticallResult(
+      streamingRatePerSecondResult,
+      "streaming_rate",
+    );
+    const superfluidToken = requireMulticallResult(
+      superfluidTokenResult,
+      "superfluid_token",
+    );
+    const superfluidGDA = requireMulticallResult(
+      superfluidGDAResult,
+      "superfluid_gda",
+    );
 
     const superTokenAddress = superfluidToken as Address;
     const gdaAddress = superfluidGDA as Address;
@@ -283,13 +332,28 @@ async function shouldRunRebalance({
       return { shouldRun: false, reason: "streaming_not_configured" };
     }
 
+    const [currentTotalFlowRateResult, superTokenBalanceResult] =
+      (await publicClient.multicall({
+        allowFailure: true,
+        contracts: [
+          {
+            address: gdaAddress,
+            abi: SUPERFLUID_POOL_ABI,
+            functionName: "getTotalFlowRate",
+          },
+          {
+            address: superTokenAddress,
+            abi: SUPER_TOKEN_ABI,
+            functionName: "balanceOf",
+            args: [strategy],
+          },
+        ] as const,
+      })) as MulticallResult[];
+
     const currentTotalFlowRate =
-      (await readOptionalBigInt({
-        publicClient,
-        address: gdaAddress,
-        abi: SUPERFLUID_POOL_ABI,
-        functionName: "getTotalFlowRate",
-      })) ?? 0n;
+      optionalMulticallBigInt(currentTotalFlowRateResult) ?? 0n;
+    const superTokenBalance =
+      optionalMulticallBigInt(superTokenBalanceResult) ?? 0n;
 
     const proposalCount = Number(proposalCounter);
     if (proposalCount === 0) {
@@ -298,80 +362,86 @@ async function shouldRunRebalance({
         : { shouldRun: true, reason: "no_proposals_stop_flow" };
     }
 
-    if (BigInt(poolAmount) === 0n && currentTotalFlowRate === 0n) {
+    if (BigInt(poolAmount as bigint) === 0n && currentTotalFlowRate === 0n) {
       return { shouldRun: false, reason: "pool_empty_zero_flow" };
     }
 
-    const superTokenBalance =
-      (await readOptionalBigInt({
-        publicClient,
-        address: superTokenAddress,
-        abi: SUPER_TOKEN_ABI,
-        functionName: "balanceOf",
-        args: [strategy],
-      })) ?? 0n;
-
     const decay = getCvParam(cvParams, 2, "decay");
-    const proposals: Array<{
+    const proposalContracts = Array.from(
+      { length: proposalCount },
+      (_, index) => BigInt(index + 1),
+    ).flatMap((proposalId) => [
+      {
+        address: strategy,
+        abi: REBALANCE_KEEPER_ABI,
+        functionName: "getProposal",
+        args: [proposalId],
+      },
+      {
+        address: strategy,
+        abi: REBALANCE_KEEPER_ABI,
+        functionName: "streamingEscrow",
+        args: [proposalId],
+      },
+      {
+        address: strategy,
+        abi: REBALANCE_KEEPER_ABI,
+        functionName: "calculateProposalConviction",
+        args: [proposalId],
+      },
+    ]);
+    const proposalResults = await multicallInChunks({
+      publicClient,
+      contracts: proposalContracts,
+    });
+
+    const proposalSnapshots: Array<{
       escrow: Address;
       status: number;
       conviction: bigint;
-      currentUnits: bigint;
-      currentFlowRate: bigint;
     }> = [];
 
-    for (let id = 1; id <= proposalCount; id++) {
-      const [proposal, escrowAddress] = await Promise.all([
-        publicClient.readContract({
-          address: strategy,
-          abi: REBALANCE_KEEPER_ABI,
-          functionName: "getProposal",
-          args: [BigInt(id)],
-        }),
-        publicClient.readContract({
-          address: strategy,
-          abi: REBALANCE_KEEPER_ABI,
-          functionName: "streamingEscrow",
-          args: [BigInt(id)],
-        }),
-      ]);
+    for (let index = 0; index < proposalCount; index++) {
+      const resultIndex = index * 3;
+      const proposal = requireMulticallResult(
+        proposalResults[resultIndex],
+        `proposal_${index + 1}`,
+      );
+      const escrowAddress = requireMulticallResult(
+        proposalResults[resultIndex + 1],
+        `proposal_${index + 1}_escrow`,
+      );
+      const conviction = requireMulticallResult(
+        proposalResults[resultIndex + 2],
+        `proposal_${index + 1}_conviction`,
+      );
       const escrow = escrowAddress as Address;
       if (escrow === ZERO_ADDRESS) continue;
 
-      const [conviction, currentUnits, currentFlowRate] = await Promise.all([
-        publicClient.readContract({
-          address: strategy,
-          abi: REBALANCE_KEEPER_ABI,
-          functionName: "calculateProposalConviction",
-          args: [BigInt(id)],
-        }),
-        readOptionalBigInt({
-          publicClient,
+      proposalSnapshots.push({
+        escrow,
+        status: getProposalStatus(proposal),
+        conviction: BigInt(conviction as bigint),
+      });
+    }
+
+    const memberResults = await multicallInChunks({
+      publicClient,
+      contracts: proposalSnapshots.flatMap((proposal) => [
+        {
           address: gdaAddress,
           abi: SUPERFLUID_POOL_ABI,
           functionName: "getUnits",
-          args: [escrow],
-        }),
-        readOptionalBigInt({
-          publicClient,
+          args: [proposal.escrow],
+        },
+        {
           address: gdaAddress,
           abi: SUPERFLUID_POOL_ABI,
           functionName: "getMemberFlowRate",
-          args: [escrow],
-        }),
-      ]);
-
-      const status = getProposalStatus(proposal);
-      const convictionValue = BigInt(conviction);
-
-      proposals.push({
-        escrow,
-        status,
-        conviction: convictionValue,
-        currentUnits: currentUnits ?? 0n,
-        currentFlowRate: currentFlowRate ?? 0n,
-      });
-    }
+          args: [proposal.escrow],
+        },
+      ]),
+    });
 
     return safeEvaluateRebalanceDecision(
       {
@@ -379,20 +449,22 @@ async function shouldRunRebalance({
         // _isStrategyEnabled selector is not exposed on every strategy diamond.
         isStrategyEnabled: true,
         proposalCount,
-        poolAmount: BigInt(poolAmount),
-        totalPointsActivated: BigInt(totalPointsActivated),
+        poolAmount: BigInt(poolAmount as bigint),
+        totalPointsActivated: BigInt(totalPointsActivated as bigint),
         decay,
-        threshold: BigInt(threshold),
-        streamingRatePerSecond: BigInt(streamingRatePerSecond),
+        threshold: BigInt(threshold as bigint),
+        streamingRatePerSecond: BigInt(streamingRatePerSecond as bigint),
         superTokenBalance,
         currentTotalFlowRate,
         hasStreamingConfig: true,
         thresholdBps,
-        proposals: proposals.map((proposal) => ({
+        proposals: proposalSnapshots.map((proposal, index) => ({
           status: proposal.status,
           conviction: proposal.conviction,
-          currentUnits: proposal.currentUnits,
-          currentFlowRate: proposal.currentFlowRate,
+          currentUnits:
+            optionalMulticallBigInt(memberResults[index * 2]) ?? 0n,
+          currentFlowRate:
+            optionalMulticallBigInt(memberResults[index * 2 + 1]) ?? 0n,
           hasEscrow: true,
         })),
       },

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -17,7 +17,8 @@
     "add-user-score": "curl -X POST http://localhost:3000/api/passport-oracle/writeScore -H 'Content-Type: application/json' -d '{\"user\":\"0x584ddfb0bdd922ff1fbf3e85e7e781d5816b4f23\"}'",
     "add-strategy": "curl -X POST http://localhost:3000/api/passport-oracle/addStrategy -H 'Content-Type: application/json' -d '{\"strategy\":\"0xfbeb532e7188cf8765e0e0141bedc076593172e2\",\"threshold\":\"200000\"}'",
     "daily-job": "curl -X GET http://localhost:3000/api/passport-oracle/dailyJob",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test:unit": "vitest run"
   },
   "dependencies": {
     "@allo-team/allo-v2-sdk": "^1.0.34",
@@ -115,6 +116,7 @@
     "tsconfig": "workspace:*",
     "typescript": "~5.2.2",
     "typescript-eslint": "^7.16.0",
-    "uglify-es": "^3.3.9"
+    "uglify-es": "^3.3.9",
+    "vitest": "^4.1.6"
   }
 }

--- a/pkg/contracts/src/CVStrategy/facets/CVStreamingFacet.sol
+++ b/pkg/contracts/src/CVStrategy/facets/CVStreamingFacet.sol
@@ -26,9 +26,6 @@ interface IStreamingEscrowSync {
 contract CVStreamingFacet is CVStrategyBaseFacet, CVStreamingBase {
     using SuperTokenV1Library for ISuperToken;
 
-    uint256 internal constant ESCROW_DEPOSIT_BUFFER_BPS = 50;
-    uint256 internal constant BPS_DENOMINATOR = 10_000;
-
     /*|--------------------------------------------|*/
     /*|              ERRORS                        |*/
     /*|--------------------------------------------|*/
@@ -352,7 +349,7 @@ contract CVStreamingFacet is CVStrategyBaseFacet, CVStreamingBase {
             return false;
         }
 
-        uint256 targetDeposit = requiredDeposit + Math.ceilDiv(requiredDeposit * ESCROW_DEPOSIT_BUFFER_BPS, BPS_DENOMINATOR);
+        uint256 targetDeposit = requiredDeposit + Math.ceilDiv(requiredDeposit * 50, 10_000);
 
         uint256 escrowBalance = superfluidToken.balanceOf(escrow);
         if (escrowBalance >= targetDeposit) {

--- a/pkg/contracts/src/CVStrategy/facets/CVStreamingFacet.sol
+++ b/pkg/contracts/src/CVStrategy/facets/CVStreamingFacet.sol
@@ -349,6 +349,7 @@ contract CVStreamingFacet is CVStrategyBaseFacet, CVStreamingBase {
             return false;
         }
 
+        // Keep a 50 bps buffer above Superfluid's required deposit to avoid tiny recurring shortfalls.
         uint256 targetDeposit = requiredDeposit + Math.ceilDiv(requiredDeposit * 50, 10_000);
 
         uint256 escrowBalance = superfluidToken.balanceOf(escrow);

--- a/pkg/contracts/src/CVStrategy/facets/CVStreamingFacet.sol
+++ b/pkg/contracts/src/CVStrategy/facets/CVStreamingFacet.sol
@@ -349,7 +349,7 @@ contract CVStreamingFacet is CVStrategyBaseFacet, CVStreamingBase {
             return false;
         }
 
-        // Keep a 50 bps buffer above Superfluid's required deposit to avoid tiny recurring shortfalls.
+        // Keep a 50 bps buffer above Superfluid's required deposit; 10_000 bps is 100%.
         uint256 targetDeposit = requiredDeposit + Math.ceilDiv(requiredDeposit * 50, 10_000);
 
         uint256 escrowBalance = superfluidToken.balanceOf(escrow);

--- a/pkg/contracts/src/CVStrategy/facets/CVStreamingFacet.sol
+++ b/pkg/contracts/src/CVStrategy/facets/CVStreamingFacet.sol
@@ -26,6 +26,9 @@ interface IStreamingEscrowSync {
 contract CVStreamingFacet is CVStrategyBaseFacet, CVStreamingBase {
     using SuperTokenV1Library for ISuperToken;
 
+    uint256 internal constant ESCROW_DEPOSIT_BUFFER_BPS = 50;
+    uint256 internal constant BPS_DENOMINATOR = 10_000;
+
     /*|--------------------------------------------|*/
     /*|              ERRORS                        |*/
     /*|--------------------------------------------|*/
@@ -349,12 +352,14 @@ contract CVStreamingFacet is CVStrategyBaseFacet, CVStreamingBase {
             return false;
         }
 
+        uint256 targetDeposit = requiredDeposit + Math.ceilDiv(requiredDeposit * ESCROW_DEPOSIT_BUFFER_BPS, BPS_DENOMINATOR);
+
         uint256 escrowBalance = superfluidToken.balanceOf(escrow);
-        if (escrowBalance >= requiredDeposit) {
+        if (escrowBalance >= targetDeposit) {
             return false;
         }
 
-        uint256 missingDeposit = requiredDeposit - escrowBalance;
+        uint256 missingDeposit = targetDeposit - escrowBalance;
         uint256 strategyBalance = superfluidToken.balanceOf(address(this));
         if (strategyBalance == 0) {
             return false;

--- a/pkg/contracts/test/CVStreamingFacet.t.sol
+++ b/pkg/contracts/test/CVStreamingFacet.t.sol
@@ -991,7 +991,7 @@ contract CVStreamingFacetTest is Test {
         assertGt(gdaAgreement.flowRate(), 0);
     }
 
-    function test_rebalance_tops_up_escrow_deposit_before_sync() public {
+    function test_rebalance_tops_up_escrow_deposit_with_buffer_before_sync() public {
         MockStreamingEscrowSync escrow = new MockStreamingEscrowSync();
         escrow.setRequiredDeposit(50 ether);
 
@@ -1001,7 +1001,38 @@ contract CVStreamingFacetTest is Test {
 
         facet.rebalance();
 
-        assertEq(superToken.balanceOf(address(escrow)), 50 ether);
+        assertEq(superToken.balanceOf(address(escrow)), 50.25 ether);
+        assertEq(escrow.syncCount(), 1);
+    }
+
+    function test_rebalance_tops_up_buffer_when_escrow_has_exact_required_deposit() public {
+        MockStreamingEscrowSync escrow = new MockStreamingEscrowSync();
+        escrow.setRequiredDeposit(50 ether);
+
+        superToken.mint(address(escrow), 50 ether);
+        superToken.mint(address(facet), 1 ether);
+        facet.setupProposal(1, ProposalStatus.Active, 1 ether, 0, block.number - 5);
+        facet.setStreamingEscrowExternal(1, address(escrow));
+
+        facet.rebalance();
+
+        assertEq(superToken.balanceOf(address(escrow)), 50.25 ether);
+        assertEq(escrow.syncCount(), 1);
+    }
+
+    function test_rebalance_does_not_top_up_when_escrow_has_buffered_deposit() public {
+        MockStreamingEscrowSync escrow = new MockStreamingEscrowSync();
+        escrow.setRequiredDeposit(50 ether);
+
+        superToken.mint(address(escrow), 50.25 ether);
+        superToken.mint(address(facet), 1 ether);
+        facet.setupProposal(1, ProposalStatus.Active, 1 ether, 0, block.number - 5);
+        facet.setStreamingEscrowExternal(1, address(escrow));
+
+        facet.rebalance();
+
+        assertEq(superToken.balanceOf(address(escrow)), 50.25 ether);
+        assertEq(superToken.balanceOf(address(facet)), 1 ether);
         assertEq(escrow.syncCount(), 1);
     }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -379,6 +379,9 @@ importers:
       uglify-es:
         specifier: ^3.3.9
         version: 3.3.9
+      vitest:
+        specifier: ^4.1.6
+        version: 4.1.6(@opentelemetry/api@1.9.0)(@types/node@20.14.4)(vite@8.0.13(@types/node@20.14.4)(esbuild@0.16.10)(jiti@1.21.6)(sass@1.77.8)(terser@5.46.0)(yaml@2.8.1))
 
   pkg/contracts: {}
 
@@ -1082,8 +1085,17 @@ packages:
     resolution: {integrity: sha512-MNsjV+Vik+ofOYmGPcdAQW4CoSSrTE2Iq2xYNS8PxV84QrgOLTsC/pV6EWb1N/dTY9ndMV/RAAzGh6cmrZf4zA==}
     engines: {node: '>=8'}
 
+  '@emnapi/core@1.10.0':
+    resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
+
+  '@emnapi/runtime@1.10.0':
+    resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
+
   '@emnapi/runtime@1.8.1':
     resolution: {integrity: sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg==}
+
+  '@emnapi/wasi-threads@1.2.1':
+    resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
 
   '@emotion/hash@0.9.1':
     resolution: {integrity: sha512-gJB6HLm5rYwSLI6PQa+X1t5CFGrv1J1TWG+sOyMCeKz2ojaj6Fnl/rZEspogG+cvqbt4AE/2eIyD2QfLKTBNlQ==}
@@ -2900,6 +2912,12 @@ packages:
     resolution: {integrity: sha512-bMVoAKhpjTOPHkW/lprDPwv5aD4R4C3Irt8vn+SKA9wudLe9COLxOhurrKRsxmZccUbWXRF7vukNeGUAj5P8kA==}
     engines: {node: '>= 10'}
 
+  '@napi-rs/wasm-runtime@1.1.4':
+    resolution: {integrity: sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==}
+    peerDependencies:
+      '@emnapi/core': ^1.7.1
+      '@emnapi/runtime': ^1.7.1
+
   '@next/env@14.2.35':
     resolution: {integrity: sha512-DuhvCtj4t9Gwrx80dmz2F4t/zKQ4ktN8WrMwOuVzkJfBilwAwGr6v16M5eI8yCuZ63H9TTuEU09Iu2HqkzFPVQ==}
 
@@ -3372,6 +3390,9 @@ packages:
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': ^1.1.0
+
+  '@oxc-project/types@0.130.0':
+    resolution: {integrity: sha512-ibD2usx9JRu7f5pu2tMKMI4cpA4NgXJQoYRP4pQ7Pxmn1l6k/53qWtQWZayhYy3X4QZkt90Ot+mJEaeXouio6Q==}
 
   '@parcel/watcher-android-arm64@2.4.1':
     resolution: {integrity: sha512-LOi/WTbbh3aTn2RYddrO8pnapixAziFl6SMxHM69r3tvdSm94JtCenaKgk1GRg5FJ5wpMCpHeW+7yqPlvZv7kg==}
@@ -4322,6 +4343,98 @@ packages:
   '@rescript/std@9.0.0':
     resolution: {integrity: sha512-zGzFsgtZ44mgL4Xef2gOy1hrRVdrs9mcxCOOKZrIPsmbZW14yTkaF591GXxpQvjXiHtgZ/iA9qLyWH6oSReIxQ==}
 
+  '@rolldown/binding-android-arm64@1.0.1':
+    resolution: {integrity: sha512-fJI3I0r3C3Oj/zdBCpaCmBRZYf07xpaq4yCfDDoSFm+beWNzbIl26puW8RraUdugoJw/95zerNOn6jasAhzSmg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@rolldown/binding-darwin-arm64@1.0.1':
+    resolution: {integrity: sha512-cKnAhWEsV7TPcA/5EAteDp6KcJZBQ2G+BqE7zayMMi7kMvwRsbv7WT9aOnn0WNl4SKEIf43vjS31iUPu80nzXg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-x64@1.0.1':
+    resolution: {integrity: sha512-YKrVwQjIRBPo+5G/u03wGjbdy4q7pyzCe93DK9VJ7zkVmeg8LJ7GbgsiHWdR4xSoe4CAXRD7Bcjgbtr64bkXNg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rolldown/binding-freebsd-x64@1.0.1':
+    resolution: {integrity: sha512-z/oBsREo46SsFqBwYtFe0kpJeBijAT48O/WXLI4suiCLBkr03RTtTJMCzSdDd2znlh8VJizL09XVkQgk8IZonw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.1':
+    resolution: {integrity: sha512-ik8q7GM11zxvYxFc2PeDcT6TBvhCQMaUxfph/M5l9sKuTs/Sjg3L+Byw0F7w0ZVLBZmx30P+gG0ECzzN+MFcmQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.1':
+    resolution: {integrity: sha512-QoSx2EkyrrdZ6kcyE8stqZ62t0Yra8Fs5ia9lOxJrh6TMQJK7gQKmscdTHf7pOXKREKrVwOtJcQG3qVSfc866A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-musl@1.0.1':
+    resolution: {integrity: sha512-uwNwFpwKeNiZawfAWBgg0VIztPTV3ihhh1vV334h9ivnNLorxnQMU6Fz8wG1Zb4Qh9LC1/MkcyT3YlDXG3Rsgg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rolldown/binding-linux-ppc64-gnu@1.0.1':
+    resolution: {integrity: sha512-zY1bul7OWr7DFBiJ++wofXvnr8B45ce3QsQUhKrIhXsygAh7bTkwyeM1bi1a2g5C/yC/N8TZyGDEoMfm/l9mpg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rolldown/binding-linux-s390x-gnu@1.0.1':
+    resolution: {integrity: sha512-0frlsT/f4Ft6I7SMESTKnF3cZsdicQn1dCMkF/jT9wDLE+gGoiQfv1nmT9e+s7s/fekvvy6tZM2jHvI2tkbJDQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+
+  '@rolldown/binding-linux-x64-gnu@1.0.1':
+    resolution: {integrity: sha512-XABVmGp9Tg0WspTVvwduTc4fpqy6JnAUrSQe6OuyqD/03nI7r0O9OWUkMIwFrjKAIqolvqoA4ZrJppgwE0Gxmw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@rolldown/binding-linux-x64-musl@1.0.1':
+    resolution: {integrity: sha512-bV4fzswuzVcKD90o/VM6QqKxnxlDq0g2BISDLNVmxrnhpv1DDbyPhCIjYfvzYLV+MvkKKnQt2Q6AO86SEBULUQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@rolldown/binding-openharmony-arm64@1.0.1':
+    resolution: {integrity: sha512-/Mh0Zhq3OP7fVs0kcQHZP6lZEthMGTaSf8UBQYSFEZDWGXXlEC+nJ6EqenaK2t4LBXMe3A+K/G2BVXXdtOr4PQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rolldown/binding-wasm32-wasi@1.0.1':
+    resolution: {integrity: sha512-+1xc9X45l8ufsBAm6Gjvx2qDRIY9lTVt0cgWNcJ+1gdhXvkbxePA60yRTwSTuXL09CMhyJmjpV7E3NoyxbqFQQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [wasm32]
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.1':
+    resolution: {integrity: sha512-1D+UqZdfnuR+Jy1GgMJwi85bD40H21uNmOPRWQhw4oRSuolZ/B5rixZ45DK2KXOTCvmVCecauWgEhbw8bI7tOw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rolldown/binding-win32-x64-msvc@1.0.1':
+    resolution: {integrity: sha512-INAycaWuhlOK3wk4mRHGsdgwYWmd9cChdPdE9bwWmy6rn9VqVNYNFGhOdXrofXUxwHIncSiPNb8tNm8knDVIeQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@rolldown/pluginutils@1.0.1':
+    resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
+
   '@rollup/plugin-commonjs@28.0.1':
     resolution: {integrity: sha512-+tNWdlWKbpB3WgBN7ijjYkq9X5uhjmcvyjEght4NmH5fAU++zfQzAJ6wumLS+dNcvwEZhKx2Z+skY8m7v0wGSA==}
     engines: {node: '>=16.0.0 || 14 >= 14.17'}
@@ -4779,6 +4892,9 @@ packages:
   '@stackso/js-core@0.5.11':
     resolution: {integrity: sha512-gq4y3Oj4yOkt9jqELOHB+qB+Jmi6GOIPokaRFVfEBcW8IiPX+Hi1jBl8/nxvfbRTRcLCdOliRDcQOiaaGs3HsQ==}
 
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
   '@stitches/core@1.2.8':
     resolution: {integrity: sha512-Gfkvwk9o9kE9r9XNBmJRfV8zONvXThnm1tcuojL04Uy5uRyqg93DC83lDebl0rocZCfKSjUv+fWYtMQmEDJldg==}
 
@@ -4951,6 +5067,9 @@ packages:
   '@tsconfig/node16@1.0.4':
     resolution: {integrity: sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==}
 
+  '@tybys/wasm-util@0.10.2':
+    resolution: {integrity: sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==}
+
   '@typechain/ethers-v6@0.5.1':
     resolution: {integrity: sha512-F+GklO8jBWlsaVV+9oHaPh5NJdd6rAKN4tklGfInX1Q7h0xPgVLP39Jl3eCulPB5qexI71ZFHwbljx4ZXNfouA==}
     peerDependencies:
@@ -4974,6 +5093,9 @@ packages:
 
   '@types/cacheable-request@6.0.3':
     resolution: {integrity: sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw==}
+
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
   '@types/connect@3.4.38':
     resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
@@ -5073,6 +5195,9 @@ packages:
 
   '@types/debug@4.1.12':
     resolution: {integrity: sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
   '@types/eslint-scope@3.7.7':
     resolution: {integrity: sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==}
@@ -5438,6 +5563,35 @@ packages:
 
   '@viem/anvil@0.0.7':
     resolution: {integrity: sha512-F+3ljCT1bEt8T4Fzm9gWpIgO3Dc7bzG1TtUtkStkJFMuummqZ8kvYc3UFMo5j3F51fSWZZvEkjs3+i7qf0AOqQ==}
+
+  '@vitest/expect@4.1.6':
+    resolution: {integrity: sha512-7EHDquPthALSV0jhhjgEW8FXaviMx7rSqu8W6oqCoAuOhKov814P99QDV1pxMA3QPv21YudvJngIhjrNI4opLg==}
+
+  '@vitest/mocker@4.1.6':
+    resolution: {integrity: sha512-MCFc63czMjEInOlcY2cpQCvCN+KgbAn+60xu9cMgP4sKaLC5JNAKw7JH8QdAnoAC88hW1IiSNZ+GgVXlN1UcMQ==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.6':
+    resolution: {integrity: sha512-h5SxD/IzNhZYnrSZRsUZQIC+vD0GY8cUvq0iwsmkFKixRCKLLWqCXa/FIQ4S1R+sI+PGoojkHsdNrbZiM9Qpgw==}
+
+  '@vitest/runner@4.1.6':
+    resolution: {integrity: sha512-nOPCmn2+yD0ZNmKdsXGv/UxMMWbMuKeD6GyYncNwdkYDxpQvrPSKYj2rWuDjC2Y4b6w6hjip5dBKFzEUuZe3vA==}
+
+  '@vitest/snapshot@4.1.6':
+    resolution: {integrity: sha512-YhsdE6xAVfTDmzjxL2ZDUvjj+ZsgyOKe+TdQzqkD72wIOmHka8NuGQ6NpTNZv9D2Z63fbwWKJPeVpEw4EQgYxw==}
+
+  '@vitest/spy@4.1.6':
+    resolution: {integrity: sha512-JFKxMx6udhwKh/Ldo270e17QX710vgunMkuPAvXjHSvC6oqLWAHhVhjg/I71q0u0CBSErIODV1Kjv0FQNSWjdg==}
+
+  '@vitest/utils@4.1.6':
+    resolution: {integrity: sha512-FxIY+U81R3LGKCxaHHFRQ5+g6/iRgGLmeHWdp2Amj4ljQRrEIWHmZyDfDYBRZlpyqA7qKxtS9DD1dhk8RnRIVQ==}
 
   '@wagmi/cli@1.5.2':
     resolution: {integrity: sha512-UfLMYhW6mQBCjR8A5s01Chf9GpHzdpcuuBuzJ36QGXcMSJAxylz5ImVZWfCRV0ct1UruydjKVSW1QSI6azNxRQ==}
@@ -6069,6 +6223,10 @@ packages:
     resolution: {integrity: sha512-fwOQNZVTMga5KRsfY80g7cpOl4PsFQczMwHzdtgoqLXaYhkhavufKb0sB0l3T1DUxpAufA0KNhlbpuuhZUwxMA==}
     hasBin: true
 
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
   ast-types-flow@0.0.8:
     resolution: {integrity: sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==}
 
@@ -6428,6 +6586,10 @@ packages:
 
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
 
   chainsaw@0.1.0:
     resolution: {integrity: sha512-75kWfWt6MEKNC8xYXIdRpDehRYY/tNSgwKaJq+dbbDcxORuVrrQ+SEHoWsniVn9XPYfP4gmdWIeDk/4YNp1rNQ==}
@@ -7857,6 +8019,10 @@ packages:
   execa@8.0.1:
     resolution: {integrity: sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==}
     engines: {node: '>=16.17'}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
 
   exponential-backoff@3.1.3:
     resolution: {integrity: sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==}
@@ -9310,6 +9476,76 @@ packages:
   lie@3.3.0:
     resolution: {integrity: sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==}
 
+  lightningcss-android-arm64@1.32.0:
+    resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [android]
+
+  lightningcss-darwin-arm64@1.32.0:
+    resolution: {integrity: sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-x64@1.32.0:
+    resolution: {integrity: sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  lightningcss-freebsd-x64@1.32.0:
+    resolution: {integrity: sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    resolution: {integrity: sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    resolution: {integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  lightningcss-linux-x64-musl@1.32.0:
+    resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    resolution: {integrity: sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [win32]
+
+  lightningcss@1.32.0:
+    resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
+    engines: {node: '>= 12.0.0'}
+
   lilconfig@2.1.0:
     resolution: {integrity: sha512-utWOt/GHzuUxnLKxB6dk81RoOeoNeHgbrXiuGk4yyF5qlRz+iIVWu56E2fqGHFrXz0QNUhLB/8nKqvRH66JKGQ==}
     engines: {node: '>=10'}
@@ -9527,6 +9763,9 @@ packages:
 
   magic-string@0.30.19:
     resolution: {integrity: sha512-2N21sPY9Ws53PZvsEpVtNuSW+ScYbQdp4b9qUaL+9QkHUrGFKo56Lg9Emg5s9V/qrtNBmiR01sYhUOwu3H+VOw==}
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
   magic-string@0.30.8:
     resolution: {integrity: sha512-ISQTe55T2ao7XtlAStud6qwYPZjE4GK1S/BeVPus4jrq6JuOnQ00YKQC581RWhR122W7msZV263KzVeLoqidyQ==}
@@ -10313,6 +10552,9 @@ packages:
   obliterator@2.0.4:
     resolution: {integrity: sha512-lgHwxlxV1qIg1Eap7LgIeoBWIMFibOjbrYPIPJZcI1mmGAI2m3lNYpK12Y+GBdPQ0U1hRwSord7GIaawz962qQ==}
 
+  obug@2.1.1:
+    resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
+
   ofetch@1.3.4:
     resolution: {integrity: sha512-KLIET85ik3vhEfS+3fDlc/BAZiAp+43QEC/yCo5zkNoY2YaKvNkOaFr/6wCFgFH1kuYQM5pMNi0Tg8koiIemtw==}
 
@@ -10737,6 +10979,10 @@ packages:
 
   postcss@8.4.38:
     resolution: {integrity: sha512-Wglpdk03BSfXkHoQa3b/oulrotAkwrlLDRSOb9D0bN86FdRyE9lppSp33aHNPgBa0JKCoB+drFLZkQoRRYae5A==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  postcss@8.5.14:
+    resolution: {integrity: sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==}
     engines: {node: ^10 || ^12 || >=14}
 
   postgres-array@2.0.0:
@@ -11368,6 +11614,11 @@ packages:
   robust-predicates@3.0.2:
     resolution: {integrity: sha512-IXgzBWvWQwE6PrDI05OvmXUIruQTcoMDzRsOd5CDvHCVLcLHMTSYvOK5Cm46kWqlV3yAbuSpBZdJ5oP5OUoStg==}
 
+  rolldown@1.0.1:
+    resolution: {integrity: sha512-X0KQHljNnEkWNqqiz9zJrGunh1B0HgOxLXvnFpCOcadzcy5qohZ3tqMEUg00vncoRovXuK3ZqCT9KnnKzoInFQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+
   rollup@4.60.1:
     resolution: {integrity: sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
@@ -11562,6 +11813,9 @@ packages:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
     engines: {node: '>= 0.4'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   signal-exit@3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
 
@@ -11666,6 +11920,9 @@ packages:
     resolution: {integrity: sha512-MGrFH9Z4NP9Iyhqn16sDtBpRRNJ0Y2hNa6D65h736fVSaPCHr4DM4sWUNvVaSuC+0OBGhwsrydQwmgfg5LncqQ==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
 
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
   stacktrace-parser@0.1.11:
     resolution: {integrity: sha512-WjlahMgHmCJpqzU8bIBy4qtsZdU9lRlcZE3Lvyej6t4tuOuv1vk57OW3MBrj6hXBFx/nNoC9MPMTcr5YA7NQbg==}
     engines: {node: '>=6'}
@@ -11679,6 +11936,9 @@ packages:
 
   std-env@3.7.0:
     resolution: {integrity: sha512-JPbdCEQLj1w5GilpiHAx3qJvFndqybBysA3qUOnznweH4QbNYUsW/ea8QzSrnh0vNsezMMw5bcVool8lM0gwzg==}
+
+  std-env@4.1.0:
+    resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
 
   stdin-discarder@0.1.0:
     resolution: {integrity: sha512-xhV7w8S+bUwlPTb4bAOUQhv8/cSS5offJuX8GQGq32ONF0ZtDWKfkdomM3HMRA+LhX6um/FZ0COqlwsjD53LeQ==}
@@ -11972,6 +12232,9 @@ packages:
     resolution: {integrity: sha512-hkcz3FjNJfKXjV4mjQ1OrXSLAehg8Hw+cEZclOVT+5c/cWQWImQ9wolzTjth+dmmDe++p3bme3fTxz6Q4Etsqw==}
     engines: {node: '>=12'}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
   tinycolor2@1.6.0:
     resolution: {integrity: sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw==}
 
@@ -11981,12 +12244,24 @@ packages:
   tinyexec@1.0.1:
     resolution: {integrity: sha512-5uC6DDlmeqiOwCPmK9jMSdOuZTh8bU39Ys6yidB+UTt5hfZUPGAypSgFRiEp+jbi9qH40BLDvy85jIU88wKSqw==}
 
+  tinyexec@1.1.2:
+    resolution: {integrity: sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==}
+    engines: {node: '>=18'}
+
   tinyglobby@0.2.14:
     resolution: {integrity: sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ==}
     engines: {node: '>=12.0.0'}
 
+  tinyglobby@0.2.16:
+    resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
+    engines: {node: '>=12.0.0'}
+
   tinygradient@1.1.5:
     resolution: {integrity: sha512-8nIfc2vgQ4TeLnk2lFj4tRLvvJwEfQuabdsmvDdQPT0xlk9TaNtpGd6nNRxXoK6vQhN6RSzj+Cnp5tTQmpxmbw==}
+
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
 
   title-case@3.0.3:
     resolution: {integrity: sha512-e1zGYRvbffpcHIrnuqT0Dh+gEJtDaxDSoG4JAIpq4oDFyooziLBIiYQv0GBT4FUAnUop5uZ1hiIAj7oAF6sOCA==}
@@ -12685,6 +12960,90 @@ packages:
       typescript:
         optional: true
 
+  vite@8.0.13:
+    resolution: {integrity: sha512-MFtjBYgzmSxmgA4RAfjIyXWpGe1oALnjgUTzzV7QLx/TKxCzjtMH6Fd9/eVK+5Fg1qNoz5VAwsmMs/NofrmJvw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      '@vitejs/devtools': ^0.1.18
+      esbuild: 0.16.10
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      '@vitejs/devtools':
+        optional: true
+      esbuild:
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@4.1.6:
+    resolution: {integrity: sha512-6lvjbS3p9b4CrdCmguzbh2/4uoXhGE2q71R4OX5sqF9R1bo9Xd6fGrMAfvp5wnCzlBnFVdCOp6onuTQVbo8iUQ==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.6
+      '@vitest/browser-preview': 4.1.6
+      '@vitest/browser-webdriverio': 4.1.6
+      '@vitest/coverage-istanbul': 4.1.6
+      '@vitest/coverage-v8': 4.1.6
+      '@vitest/ui': 4.1.6
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   vscode-jsonrpc@8.2.0:
     resolution: {integrity: sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==}
     engines: {node: '>=14.0.0'}
@@ -12844,6 +13203,11 @@ packages:
   which@4.0.0:
     resolution: {integrity: sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg==}
     engines: {node: ^16.13.0 || >=18.0.0}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   wicked-good-xpath@1.3.0:
@@ -14045,7 +14409,23 @@ snapshots:
       '@stablelib/blake2s': 1.0.1
       js-sha3: 0.8.0
 
+  '@emnapi/core@1.10.0':
+    dependencies:
+      '@emnapi/wasi-threads': 1.2.1
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/runtime@1.10.0':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
   '@emnapi/runtime@1.8.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/wasi-threads@1.2.1':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -16784,6 +17164,13 @@ snapshots:
       '@napi-rs/simple-git-win32-ia32-msvc': 0.1.22
       '@napi-rs/simple-git-win32-x64-msvc': 0.1.22
 
+  '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@tybys/wasm-util': 0.10.2
+    optional: true
+
   '@next/env@14.2.35': {}
 
   '@next/env@15.5.18': {}
@@ -17281,6 +17668,8 @@ snapshots:
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.0)
+
+  '@oxc-project/types@0.130.0': {}
 
   '@parcel/watcher-android-arm64@2.4.1':
     optional: true
@@ -18190,6 +18579,57 @@ snapshots:
 
   '@rescript/std@9.0.0': {}
 
+  '@rolldown/binding-android-arm64@1.0.1':
+    optional: true
+
+  '@rolldown/binding-darwin-arm64@1.0.1':
+    optional: true
+
+  '@rolldown/binding-darwin-x64@1.0.1':
+    optional: true
+
+  '@rolldown/binding-freebsd-x64@1.0.1':
+    optional: true
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.1':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.1':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-musl@1.0.1':
+    optional: true
+
+  '@rolldown/binding-linux-ppc64-gnu@1.0.1':
+    optional: true
+
+  '@rolldown/binding-linux-s390x-gnu@1.0.1':
+    optional: true
+
+  '@rolldown/binding-linux-x64-gnu@1.0.1':
+    optional: true
+
+  '@rolldown/binding-linux-x64-musl@1.0.1':
+    optional: true
+
+  '@rolldown/binding-openharmony-arm64@1.0.1':
+    optional: true
+
+  '@rolldown/binding-wasm32-wasi@1.0.1':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+    optional: true
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.1':
+    optional: true
+
+  '@rolldown/binding-win32-x64-msvc@1.0.1':
+    optional: true
+
+  '@rolldown/pluginutils@1.0.1': {}
+
   '@rollup/plugin-commonjs@28.0.1(rollup@4.60.1)':
     dependencies:
       '@rollup/pluginutils': 5.3.0(rollup@4.60.1)
@@ -18796,6 +19236,8 @@ snapshots:
       - utf-8-validate
       - zod
 
+  '@standard-schema/spec@1.1.0': {}
+
   '@stitches/core@1.2.8': {}
 
   '@stylistic/eslint-plugin-js@2.3.0(eslint@8.57.0)':
@@ -19068,6 +19510,11 @@ snapshots:
 
   '@tsconfig/node16@1.0.4': {}
 
+  '@tybys/wasm-util@0.10.2':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
   '@typechain/ethers-v6@0.5.1(ethers@6.16.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(typechain@8.3.2(typescript@5.2.2))(typescript@5.2.2)':
     dependencies:
       ethers: 6.16.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
@@ -19098,6 +19545,11 @@ snapshots:
       '@types/keyv': 3.1.4
       '@types/node': 20.19.30
       '@types/responselike': 1.0.3
+
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
 
   '@types/connect@3.4.38':
     dependencies:
@@ -19223,6 +19675,8 @@ snapshots:
   '@types/debug@4.1.12':
     dependencies:
       '@types/ms': 0.7.34
+
+  '@types/deep-eql@4.0.2': {}
 
   '@types/eslint-scope@3.7.7':
     dependencies:
@@ -19767,6 +20221,47 @@ snapshots:
       - bufferutil
       - debug
       - utf-8-validate
+
+  '@vitest/expect@4.1.6':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.6
+      '@vitest/utils': 4.1.6
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.6(vite@8.0.13(@types/node@20.14.4)(esbuild@0.16.10)(jiti@1.21.6)(sass@1.77.8)(terser@5.46.0)(yaml@2.8.1))':
+    dependencies:
+      '@vitest/spy': 4.1.6
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.0.13(@types/node@20.14.4)(esbuild@0.16.10)(jiti@1.21.6)(sass@1.77.8)(terser@5.46.0)(yaml@2.8.1)
+
+  '@vitest/pretty-format@4.1.6':
+    dependencies:
+      tinyrainbow: 3.1.0
+
+  '@vitest/runner@4.1.6':
+    dependencies:
+      '@vitest/utils': 4.1.6
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.6':
+    dependencies:
+      '@vitest/pretty-format': 4.1.6
+      '@vitest/utils': 4.1.6
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.6': {}
+
+  '@vitest/utils@4.1.6':
+    dependencies:
+      '@vitest/pretty-format': 4.1.6
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
 
   '@wagmi/cli@1.5.2(@wagmi/core@1.4.13(@types/react@18.3.3)(bufferutil@4.1.0)(encoding@0.1.13)(react@18.2.0)(typescript@5.2.2)(utf-8-validate@5.0.10)(viem@1.21.4(bufferutil@4.1.0)(typescript@5.2.2)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76))(bufferutil@4.1.0)(typescript@5.2.2)(utf-8-validate@5.0.10)(wagmi@1.4.13(@types/react@18.3.3)(bufferutil@4.1.0)(encoding@0.1.13)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.2.2)(utf-8-validate@5.0.10)(viem@1.21.4(bufferutil@4.1.0)(typescript@5.2.2)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76))':
     dependencies:
@@ -20797,6 +21292,8 @@ snapshots:
       long: 5.2.3
       source-map-support: 0.5.21
 
+  assertion-error@2.0.1: {}
+
   ast-types-flow@0.0.8: {}
 
   astring@1.9.0: {}
@@ -21204,6 +21701,8 @@ snapshots:
   cborg@4.3.2: {}
 
   ccount@2.0.1: {}
+
+  chai@6.2.2: {}
 
   chainsaw@0.1.0:
     dependencies:
@@ -22064,8 +22563,7 @@ snapshots:
 
   detect-libc@2.0.3: {}
 
-  detect-libc@2.1.2:
-    optional: true
+  detect-libc@2.1.2: {}
 
   detect-node-es@1.1.0: {}
 
@@ -23106,6 +23604,8 @@ snapshots:
       onetime: 6.0.0
       signal-exit: 4.1.0
       strip-final-newline: 3.0.0
+
+  expect-type@1.3.0: {}
 
   exponential-backoff@3.1.3:
     optional: true
@@ -24837,6 +25337,55 @@ snapshots:
     dependencies:
       immediate: 3.0.6
 
+  lightningcss-android-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-x64@1.32.0:
+    optional: true
+
+  lightningcss-freebsd-x64@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-musl@1.32.0:
+    optional: true
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    optional: true
+
+  lightningcss@1.32.0:
+    dependencies:
+      detect-libc: 2.1.2
+    optionalDependencies:
+      lightningcss-android-arm64: 1.32.0
+      lightningcss-darwin-arm64: 1.32.0
+      lightningcss-darwin-x64: 1.32.0
+      lightningcss-freebsd-x64: 1.32.0
+      lightningcss-linux-arm-gnueabihf: 1.32.0
+      lightningcss-linux-arm64-gnu: 1.32.0
+      lightningcss-linux-arm64-musl: 1.32.0
+      lightningcss-linux-x64-gnu: 1.32.0
+      lightningcss-linux-x64-musl: 1.32.0
+      lightningcss-win32-arm64-msvc: 1.32.0
+      lightningcss-win32-x64-msvc: 1.32.0
+
   lilconfig@2.1.0: {}
 
   lilconfig@3.1.2: {}
@@ -25035,6 +25584,10 @@ snapshots:
       multiaddr: 7.5.0
 
   magic-string@0.30.19:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
@@ -26255,6 +26808,8 @@ snapshots:
 
   obliterator@2.0.4: {}
 
+  obug@2.1.1: {}
+
   ofetch@1.3.4:
     dependencies:
       destr: 2.0.3
@@ -26714,6 +27269,12 @@ snapshots:
       nanoid: 3.3.11
       picocolors: 1.0.1
       source-map-js: 1.2.0
+
+  postcss@8.5.14:
+    dependencies:
+      nanoid: 3.3.11
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
 
   postgres-array@2.0.0: {}
 
@@ -27441,6 +28002,27 @@ snapshots:
 
   robust-predicates@3.0.2: {}
 
+  rolldown@1.0.1:
+    dependencies:
+      '@oxc-project/types': 0.130.0
+      '@rolldown/pluginutils': 1.0.1
+    optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.0.1
+      '@rolldown/binding-darwin-arm64': 1.0.1
+      '@rolldown/binding-darwin-x64': 1.0.1
+      '@rolldown/binding-freebsd-x64': 1.0.1
+      '@rolldown/binding-linux-arm-gnueabihf': 1.0.1
+      '@rolldown/binding-linux-arm64-gnu': 1.0.1
+      '@rolldown/binding-linux-arm64-musl': 1.0.1
+      '@rolldown/binding-linux-ppc64-gnu': 1.0.1
+      '@rolldown/binding-linux-s390x-gnu': 1.0.1
+      '@rolldown/binding-linux-x64-gnu': 1.0.1
+      '@rolldown/binding-linux-x64-musl': 1.0.1
+      '@rolldown/binding-openharmony-arm64': 1.0.1
+      '@rolldown/binding-wasm32-wasi': 1.0.1
+      '@rolldown/binding-win32-arm64-msvc': 1.0.1
+      '@rolldown/binding-win32-x64-msvc': 1.0.1
+
   rollup@4.60.1:
     dependencies:
       '@types/estree': 1.0.8
@@ -27752,6 +28334,8 @@ snapshots:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
+  siginfo@2.0.0: {}
+
   signal-exit@3.0.7: {}
 
   signal-exit@4.1.0: {}
@@ -27859,6 +28443,8 @@ snapshots:
       minipass: 7.1.2
     optional: true
 
+  stackback@0.0.2: {}
+
   stacktrace-parser@0.1.11:
     dependencies:
       type-fest: 0.7.1
@@ -27873,6 +28459,8 @@ snapshots:
   statuses@2.0.1: {}
 
   std-env@3.7.0: {}
+
+  std-env@4.1.0: {}
 
   stdin-discarder@0.1.0:
     dependencies:
@@ -28197,13 +28785,22 @@ snapshots:
 
   tiny-lru@11.4.5: {}
 
+  tinybench@2.9.0: {}
+
   tinycolor2@1.6.0: {}
 
   tinyexec@0.3.2: {}
 
   tinyexec@1.0.1: {}
 
+  tinyexec@1.1.2: {}
+
   tinyglobby@0.2.14:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+
+  tinyglobby@0.2.16:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
@@ -28212,6 +28809,8 @@ snapshots:
     dependencies:
       '@types/tinycolor2': 1.4.6
       tinycolor2: 1.6.0
+
+  tinyrainbow@3.1.0: {}
 
   title-case@3.0.3:
     dependencies:
@@ -29044,6 +29643,50 @@ snapshots:
       - utf-8-validate
       - zod
 
+  vite@8.0.13(@types/node@20.14.4)(esbuild@0.16.10)(jiti@1.21.6)(sass@1.77.8)(terser@5.46.0)(yaml@2.8.1):
+    dependencies:
+      lightningcss: 1.32.0
+      picomatch: 4.0.4
+      postcss: 8.5.14
+      rolldown: 1.0.1
+      tinyglobby: 0.2.16
+    optionalDependencies:
+      '@types/node': 20.14.4
+      esbuild: 0.16.10
+      fsevents: 2.3.3
+      jiti: 1.21.6
+      sass: 1.77.8
+      terser: 5.46.0
+      yaml: 2.8.1
+
+  vitest@4.1.6(@opentelemetry/api@1.9.0)(@types/node@20.14.4)(vite@8.0.13(@types/node@20.14.4)(esbuild@0.16.10)(jiti@1.21.6)(sass@1.77.8)(terser@5.46.0)(yaml@2.8.1)):
+    dependencies:
+      '@vitest/expect': 4.1.6
+      '@vitest/mocker': 4.1.6(vite@8.0.13(@types/node@20.14.4)(esbuild@0.16.10)(jiti@1.21.6)(sass@1.77.8)(terser@5.46.0)(yaml@2.8.1))
+      '@vitest/pretty-format': 4.1.6
+      '@vitest/runner': 4.1.6
+      '@vitest/snapshot': 4.1.6
+      '@vitest/spy': 4.1.6
+      '@vitest/utils': 4.1.6
+      es-module-lexer: 2.0.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.1.2
+      tinyglobby: 0.2.16
+      tinyrainbow: 3.1.0
+      vite: 8.0.13(@types/node@20.14.4)(esbuild@0.16.10)(jiti@1.21.6)(sass@1.77.8)(terser@5.46.0)(yaml@2.8.1)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.0
+      '@types/node': 20.14.4
+    transitivePeerDependencies:
+      - msw
+
   vscode-jsonrpc@8.2.0: {}
 
   vscode-languageserver-protocol@3.17.5:
@@ -29315,6 +29958,11 @@ snapshots:
     dependencies:
       isexe: 3.1.1
     optional: true
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   wicked-good-xpath@1.3.0: {}
 


### PR DESCRIPTION
## Summary

- Add a TypeScript rebalance decision preflight for the keeper that mirrors CVStreamingFacet streaming-rate/unit behavior and skips no-op or insignificant updates.
- Return strategy/community metadata and app URIs in keeper results, skip testnet USD gas cost enrichment, and omit rebalance reasons from skipped strategies.
- Add a buffered escrow top-up in CVStreamingFacet, while removing escrow top-up as a keeper reason to rebalance.
- Add unit coverage for the keeper decision algorithm and Solidity coverage for the escrow deposit buffer behavior.

## Validation

- `pnpm test:unit -- 'app/api/rebalance-keeper/[chain]/rebalanceDecision.test.ts'`
- `pnpm typecheck`
- `pnpm lint --file 'app/api/rebalance-keeper/[chain]/route.ts' --file 'app/api/rebalance-keeper/[chain]/rebalanceDecision.ts' --file 'app/api/rebalance-keeper/[chain]/rebalanceDecision.test.ts'`
- `forge test --root ../.. --match-path pkg/contracts/test/CVStreamingFacet.t.sol --match-test 'test_rebalance_tops_up|test_rebalance_does_not_top_up|test_rebalance_transfer_failure_reverts_on_top_up' -vvv`