### PR TITLE
Refactor web pubsub strategy scopes

### DIFF
--- a/apps/web/app/(app)/gardens/[chain]/[community]/[pool]/[proposalId]/client-page.tsx
+++ b/apps/web/app/(app)/gardens/[chain]/[community]/[pool]/[proposalId]/client-page.tsx
@@ -347,7 +347,6 @@ export default function ClientPage({ params }: ClientPageProps) {
   }, []);
 
   const strategyAddress = poolSlug.toLowerCase();
-  const [poolIdForScope, setPoolIdForScope] = useState<number | undefined>();
   const [convictionRefreshing, setConvictionRefreshing] = useState(true);
   const [openSupportersModal, setOpenSupportersModal] = useState(false);
   const [selectedTab, setSelectedTab] = useState(0);
@@ -366,6 +365,7 @@ export default function ClientPage({ params }: ClientPageProps) {
 
   const { address } = useAccount();
   const routerSearchParams = useSearchParams();
+
   const collectedParams = useCollectQueryParams();
   const [initialSearchParams] = useState<Record<string, string> | null>(() => {
     if (typeof window === "undefined") return null;
@@ -385,10 +385,10 @@ export default function ClientPage({ params }: ClientPageProps) {
       communityId: communityAddr?.toLowerCase(),
     },
     changeScope:
-      poolIdForScope != null ?
+      strategyAddress != null ?
         {
           topic: "proposal",
-          containerId: poolIdForScope,
+          containerId: strategyAddress,
           id: proposalNumber,
           type: "update",
         }
@@ -412,10 +412,10 @@ export default function ClientPage({ params }: ClientPageProps) {
         strategyId: strategyAddress,
       },
       changeScope:
-        poolIdForScope != null ?
+        strategyAddress != null ?
           {
             topic: "proposal",
-            containerId: poolIdForScope,
+            containerId: strategyAddress,
             type: "update",
           }
         : undefined,
@@ -463,23 +463,8 @@ export default function ClientPage({ params }: ClientPageProps) {
     });
     return activatedPoints;
   }, [membersStrategyData?.memberStrategies, strategyAddress]);
-  const resolvedPoolId =
-    proposalData?.strategy?.poolId != null ?
-      Number(proposalData.strategy.poolId)
-    : undefined;
-  const poolId = resolvedPoolId;
   const totalEffectiveActivePoints =
     proposalData?.strategy?.totalEffectiveActivePoints;
-
-  useEffect(() => {
-    if (
-      resolvedPoolId != null &&
-      resolvedPoolId !== poolIdForScope &&
-      Number.isFinite(resolvedPoolId)
-    ) {
-      setPoolIdForScope(resolvedPoolId);
-    }
-  }, [resolvedPoolId, poolIdForScope]);
 
   const filteredAndSortedProposalSupporters: ProposalSupporter[] =
     proposalSupporters ?
@@ -627,11 +612,10 @@ export default function ClientPage({ params }: ClientPageProps) {
     proposalStatus !== "executed" && proposalStatus !== "cancelled";
 
   const poolTokenResult = usePoolToken({
-    poolAddress: proposalData?.strategy?.id,
+    poolAddress: strategyAddress,
     poolTokenAddr,
     chainId,
-    enabled:
-      !!poolTokenAddr && !!proposalData?.strategy?.id && !isSignalingType,
+    enabled: !!poolTokenAddr && !!strategyAddress && !isSignalingType,
   });
   const poolToken = poolTokenResult?.poolToken;
   const { superToken: poolSuperToken } = useSuperfluidToken({
@@ -683,7 +667,7 @@ export default function ClientPage({ params }: ClientPageProps) {
     receiver: resolvedStreamingEscrow as Address,
     superToken: proposalData?.strategy?.config?.superfluidToken as Address,
     chainId,
-    containerId: poolId ?? proposalSlug,
+    containerId: strategyAddress,
   });
   const explorerTotalStreamedBn = (
     superfluidStreamResult as typeof superfluidStreamResult & {
@@ -763,7 +747,7 @@ export default function ClientPage({ params }: ClientPageProps) {
       !supportersData ||
       proposalIdNumber == null ||
       updatedConviction == null ||
-      poolId == null);
+      strategyAddress == null);
 
   useEffect(() => {
     if (fetching || !isAwaitingProposal) return;
@@ -827,7 +811,7 @@ export default function ClientPage({ params }: ClientPageProps) {
         type: "update",
         function: "distribute",
         id: proposalNumber,
-        containerId: poolId,
+        containerId: strategyAddress,
         chainId,
       });
     },
@@ -968,7 +952,7 @@ export default function ClientPage({ params }: ClientPageProps) {
         void refetchLastRebalanceAt();
         publish({
           topic: "stream",
-          containerId: poolId,
+          containerId: strategyAddress,
           function: "rebalance",
         } as any);
       },
@@ -1107,7 +1091,7 @@ export default function ClientPage({ params }: ClientPageProps) {
     !supportersData ||
     proposalIdNumber == null ||
     updatedConviction == null ||
-    poolId == null
+    strategyAddress == null
   ) {
     return (
       <div className="col-span-12 flex min-h-[40vh] items-center justify-center">
@@ -1283,31 +1267,33 @@ export default function ClientPage({ params }: ClientPageProps) {
                   >
                     Go to Vote on Proposals
                   </Button>
-                  {!isSignalingType && !isStreamingType && (
-                    <Button
-                      icon={<BoltIcon height={18} width={18} />}
-                      className="!w-full"
-                      testId="btn-execute-proposal"
-                      onClick={() =>
-                        writeDistribute?.({
-                          args: [
-                            BigInt(poolId),
-                            [proposalData?.strategy?.id as Address],
-                            encodedDataProposalId(proposalIdNumber),
-                          ],
-                        })
-                      }
-                      disabled={
-                        isExecuteButtonDisabled ||
-                        !isConnected ||
-                        missmatchUrl ||
-                        proposalStatus === "disputed"
-                      }
-                      tooltip={executeBtnTooltipMessage}
-                    >
-                      Execute
-                    </Button>
-                  )}
+                  {!isSignalingType &&
+                    !isStreamingType &&
+                    proposalData?.strategy != null && (
+                      <Button
+                        icon={<BoltIcon height={18} width={18} />}
+                        className="!w-full"
+                        testId="btn-execute-proposal"
+                        onClick={() =>
+                          writeDistribute?.({
+                            args: [
+                              BigInt(proposalData.strategy.poolId),
+                              [proposalData.strategy.id as Address],
+                              encodedDataProposalId(proposalIdNumber),
+                            ],
+                          })
+                        }
+                        disabled={
+                          isExecuteButtonDisabled ||
+                          !isConnected ||
+                          missmatchUrl ||
+                          proposalStatus === "disputed"
+                        }
+                        tooltip={executeBtnTooltipMessage}
+                      >
+                        Execute
+                      </Button>
+                    )}
                 </div>
               </div>
             )}
@@ -1852,30 +1838,32 @@ export default function ClientPage({ params }: ClientPageProps) {
                       >
                         Vote on Proposals
                       </Button>
-                      {!isSignalingType && !isStreamingType && (
-                        <Button
-                          icon={<BoltIcon height={18} width={18} />}
-                          className="w-full"
-                          onClick={() =>
-                            writeDistribute?.({
-                              args: [
-                                BigInt(poolId),
-                                [proposalData?.strategy?.id as Address],
-                                encodedDataProposalId(proposalIdNumber),
-                              ],
-                            })
-                          }
-                          disabled={
-                            isExecuteButtonDisabled ||
-                            !isConnected ||
-                            missmatchUrl ||
-                            proposalStatus === "disputed"
-                          }
-                          tooltip={executeBtnTooltipMessage}
-                        >
-                          Execute
-                        </Button>
-                      )}
+                      {!isSignalingType &&
+                        !isStreamingType &&
+                        proposalData?.strategy != null && (
+                          <Button
+                            icon={<BoltIcon height={18} width={18} />}
+                            className="w-full"
+                            onClick={() =>
+                              writeDistribute?.({
+                                args: [
+                                  BigInt(proposalData.strategy.poolId),
+                                  [proposalData.strategy.id as Address],
+                                  encodedDataProposalId(proposalIdNumber),
+                                ],
+                              })
+                            }
+                            disabled={
+                              isExecuteButtonDisabled ||
+                              !isConnected ||
+                              missmatchUrl ||
+                              proposalStatus === "disputed"
+                            }
+                            tooltip={executeBtnTooltipMessage}
+                          >
+                            Execute
+                          </Button>
+                        )}
                     </div>
                   </div>
                 )}

--- a/apps/web/app/(app)/gardens/[chain]/[community]/[pool]/client-page.tsx
+++ b/apps/web/app/(app)/gardens/[chain]/[community]/[pool]/client-page.tsx
@@ -186,7 +186,6 @@ export default function ClientPage({
   const newPoolId = searchParams[QUERY_PARAMS.communityPage.newPool];
   const strategyAddress = poolSlug.toLowerCase();
   const pendingNewPoolRefetch = useRef<string | null>(null);
-  const [poolIdForScope, setPoolIdForScope] = useState<number | undefined>();
   const [hasResolvedInitialNewPoolLookup, setHasResolvedInitialNewPoolLookup] =
     useState(() => !Boolean(newPoolId));
   const { data, error, refetch, fetching } = useSubgraphQuery<getPoolDataQuery>(
@@ -197,30 +196,27 @@ export default function ClientPage({
       },
       changeScope: [
         {
+          topic: "pool",
+          id: strategyAddress,
+          type: "update",
+        },
+        {
           topic: "proposal",
           containerId: strategyAddress,
           type: "update",
         },
-        ...(poolIdForScope != null ?
-          [
-            {
-              topic: "pool" as const,
-              id: poolIdForScope,
-            },
-            {
-              topic: "member" as const,
-              function: "activatePoints",
-              type: "update" as const,
-              containerId: strategyAddress,
-            },
-            {
-              topic: "member" as const,
-              function: "deactivatePoints",
-              type: "update" as const,
-              containerId: strategyAddress,
-            },
-          ]
-        : []),
+        {
+          topic: "member" as const,
+          function: "activatePoints",
+          type: "update" as const,
+          containerId: strategyAddress,
+        },
+        {
+          topic: "member" as const,
+          function: "deactivatePoints",
+          type: "update" as const,
+          containerId: strategyAddress,
+        },
       ],
     },
   );
@@ -256,16 +252,6 @@ export default function ClientPage({
       }
     });
   }, [newPoolId, strategy, error]);
-
-  useEffect(() => {
-    if (
-      resolvedPoolId != null &&
-      resolvedPoolId !== poolIdForScope &&
-      Number.isFinite(resolvedPoolId)
-    ) {
-      setPoolIdForScope(resolvedPoolId);
-    }
-  }, [resolvedPoolId, poolIdForScope]);
 
   useEffect(() => {
     if (newPoolId && strategy) {

--- a/apps/web/app/(app)/gardens/[chain]/[community]/[pool]/client-page.tsx
+++ b/apps/web/app/(app)/gardens/[chain]/[community]/[pool]/client-page.tsx
@@ -139,18 +139,21 @@ const LivePoolStreamedTotal = memo(function LivePoolStreamedTotal({
     }, 0n);
 
     const totalFlowRateBn =
-      freezeAtSnapshot ? 0n
-      : (proposals ?? []).reduce(
+      freezeAtSnapshot ? 0n : (
+        (proposals ?? []).reduce(
           (acc, proposal) =>
             acc + toBigInt(getProposalStream(proposal)?.currentFlowRate),
           0n,
-        );
+        )
+      );
 
     return {
       totalStreamedValue:
         total > 0n ? Number(formatUnits(total, poolToken.decimals)) : null,
       totalStreamedRatePerSecond:
-        totalFlowRateBn > 0n ? Number(formatUnits(totalFlowRateBn, poolToken.decimals)) : 0,
+        totalFlowRateBn > 0n ?
+          Number(formatUnits(totalFlowRateBn, poolToken.decimals))
+        : 0,
     };
   }, [freezeAtSnapshot, poolToken, proposals]);
 
@@ -192,32 +195,33 @@ export default function ClientPage({
       variables: {
         strategyId: strategyAddress,
       },
-      changeScope:
-        poolIdForScope != null ?
+      changeScope: [
+        {
+          topic: "proposal",
+          containerId: strategyAddress,
+          type: "update",
+        },
+        ...(poolIdForScope != null ?
           [
             {
-              topic: "pool",
+              topic: "pool" as const,
               id: poolIdForScope,
             },
             {
-              topic: "proposal",
-              containerId: poolIdForScope,
-              type: "update",
-            },
-            {
-              topic: "member",
+              topic: "member" as const,
               function: "activatePoints",
-              type: "update",
-              containerId: poolIdForScope,
+              type: "update" as const,
+              containerId: strategyAddress,
             },
             {
-              topic: "member",
+              topic: "member" as const,
               function: "deactivatePoints",
-              type: "update",
-              containerId: poolIdForScope,
+              type: "update" as const,
+              containerId: strategyAddress,
             },
           ]
-        : undefined,
+        : []),
+      ],
     },
   );
 
@@ -367,7 +371,7 @@ export default function ClientPage({
           },
           {
             topic: "proposal",
-            containerId: poolId,
+            containerId: strategyAddress,
             function: "allocate",
           },
         ]
@@ -386,10 +390,10 @@ export default function ClientPage({
           [
             {
               topic: "proposal",
-              containerId: poolId,
+              containerId: strategyAddress,
               type: "update",
             },
-            { topic: "member", id: wallet, containerId: poolId },
+            { topic: "member", id: wallet, containerId: strategyAddress },
           ]
         : undefined,
       enabled: !!wallet && !!strategy?.id,
@@ -402,7 +406,7 @@ export default function ClientPage({
     isMemberCommunityResult?.isRegistered ? isMemberCommunityResult
     : memberCommunityFromPoolResult?.isRegistered ?
       memberCommunityFromPoolResult
-    : (isMemberCommunityResult ?? memberCommunityFromPoolResult);
+    : isMemberCommunityResult ?? memberCommunityFromPoolResult;
 
   const memberTokensInCommunity = BigInt(
     memberCommunityData?.stakedTokens ?? 0,
@@ -419,11 +423,11 @@ export default function ClientPage({
           [
             {
               topic: "proposal",
-              containerId: poolId,
+              containerId: strategyAddress,
               type: "update",
             },
             ...(wallet ?
-              [{ topic: "member" as const, id: wallet, containerId: poolId }]
+              [{ topic: "member" as const, id: wallet, containerId: strategyAddress }]
             : []),
           ]
         : undefined,
@@ -504,7 +508,7 @@ export default function ClientPage({
       {
         topic: "member",
         id: wallet,
-        containerId: poolId ?? strategy?.poolId,
+        containerId: strategyAddress,
         type: "update",
       },
       () => {
@@ -516,7 +520,7 @@ export default function ClientPage({
         unsubscribe(subscriptionId.current);
       }
     };
-  }, [connected, poolId]);
+  }, [connected, strategyAddress]);
 
   const poolTokenAddr = strategy?.token as Address;
 
@@ -617,7 +621,7 @@ export default function ClientPage({
   const maxAmount = strategy?.config?.maxAmount ?? 0;
 
   const { poolToken, isLoading: isPoolTokenLoading } = usePoolToken({
-    poolAddress: strategy?.id,
+    poolAddress: strategyAddress,
     poolTokenAddr: poolTokenAddr,
     chainId,
     enabled:
@@ -707,9 +711,10 @@ export default function ClientPage({
       onConfirmations: () => {
         void refetchLastRebalanceAt();
         publish({
-          topic: "proposal",
-          containerId: poolId,
+          topic: "stream",
+          containerId: strategyAddress,
           function: "rebalance",
+          chainId,
         });
       },
     });
@@ -745,9 +750,8 @@ export default function ClientPage({
     receiver: (streamInfo?.superfluidGDA ?? "") as Address,
     superToken: (effectiveSuperToken ?? "") as Address,
     chainId,
-    containerId:
-      streamInfo?.superfluidGDA ?? poolId ?? strategy?.id ?? "pool-stream",
-    sender: strategy?.id,
+    containerId: strategyAddress,
+    sender: strategyAddress,
     includePoolMembers: false,
   });
   const proposalFlowRateFallbackBn = useMemo(
@@ -765,8 +769,7 @@ export default function ClientPage({
   const currentFlowRateForDisplay =
     liveCurrentFlowRateBn != null && liveCurrentFlowRateBn > 0n ?
       liveCurrentFlowRateBn
-    : streamLastFlowRate != null && streamLastFlowRate > 0n ?
-      streamLastFlowRate
+    : streamLastFlowRate != null && streamLastFlowRate > 0n ? streamLastFlowRate
     : proposalFlowRateFallbackBn;
   const hasEligibleStreamingProposal = useMemo(
     () =>

--- a/apps/web/app/api/rebalance-keeper/[chain]/route.ts
+++ b/apps/web/app/api/rebalance-keeper/[chain]/route.ts
@@ -135,13 +135,24 @@ const GARDENS_APP_BASE_URL = "https://app.gardens.fund";
 const PROPOSAL_MULTICALL_CHUNK_SIZE = 75;
 
 let ablyClient: Ably.Rest | null = null;
+let hasWarnedMissingAblyKey = false;
 
 const getAblyClient = () => {
   if (ablyClient != null) return ablyClient;
 
   const key = process.env.NEXT_ABLY_API_KEY;
-  if (!key) return null;
+  if (!key) {
+    if (!hasWarnedMissingAblyKey) {
+      console.warn(
+        "rebalance-keeper: NEXT_ABLY_API_KEY is unset; stream updates will not be published",
+      );
+      hasWarnedMissingAblyKey = true;
+    }
+    return null;
+  }
 
+  // Ably.Rest uses plain HTTP requests, so reusing a client here is only to
+  // avoid rebuilding it for every rebalance confirmation.
   ablyClient = new Ably.Rest({ key });
   return ablyClient;
 };

--- a/apps/web/app/api/rebalance-keeper/[chain]/route.ts
+++ b/apps/web/app/api/rebalance-keeper/[chain]/route.ts
@@ -1,3 +1,4 @@
+import Ably from "ably";
 import { NextResponse } from "next/server";
 import {
   Address,
@@ -16,6 +17,7 @@ import {
   safeEvaluateRebalanceDecision,
 } from "./rebalanceDecision";
 import { chainConfigMap, getConfigByChain } from "@/configs/chains";
+import { CHANGE_EVENT_CHANNEL_NAME } from "@/globals";
 import { getGasTokenUsdPrice } from "@/services/coingecko";
 import { ChainId } from "@/types";
 import { getViemChain } from "@/utils/web3";
@@ -131,6 +133,36 @@ const REBALANCE_KEEPER_EXCLUDED_CHAIN_IDS = new Set<number>([421614]);
 const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
 const GARDENS_APP_BASE_URL = "https://app.gardens.fund";
 const PROPOSAL_MULTICALL_CHUNK_SIZE = 75;
+
+let ablyClient: Ably.Rest | null = null;
+
+const getAblyClient = () => {
+  if (ablyClient != null) return ablyClient;
+
+  const key = process.env.NEXT_ABLY_API_KEY;
+  if (!key) return null;
+
+  ablyClient = new Ably.Rest({ key });
+  return ablyClient;
+};
+
+const publishStreamRebalance = async ({
+  chainId,
+  strategy,
+}: {
+  chainId: ChainId;
+  strategy: Address;
+}) => {
+  const client = getAblyClient();
+  if (!client) return;
+
+  await client.channels.get(CHANGE_EVENT_CHANNEL_NAME).publish("stream", {
+    topic: "stream",
+    function: "rebalance",
+    containerId: strategy,
+    chainId,
+  });
+};
 
 const roundToUsdPrecision = (value: number) =>
   Math.round(value * USD_PRECISION_MULTIPLIER) / USD_PRECISION_MULTIPLIER;
@@ -886,6 +918,20 @@ async function runKeeperForChain({
           chainId: chainConfig.id,
           ...confirmedTx,
         });
+
+        try {
+          await publishStreamRebalance({
+            chainId: chainConfig.id,
+            strategy,
+          });
+        } catch (error) {
+          console.warn("rebalance-keeper: failed to publish stream update", {
+            chainId: chainConfig.id,
+            strategy,
+            txHash: hash,
+            error: error instanceof Error ? error.message : "unknown_error",
+          });
+        }
 
         sent.push(confirmedTx);
       } catch (error) {

--- a/apps/web/components/ActivatePoints.tsx
+++ b/apps/web/components/ActivatePoints.tsx
@@ -58,7 +58,7 @@ export function ActivatePoints({
         id: connectedAccount,
         type: "update",
         function: "activatePoints",
-        containerId: strategy.poolId,
+        containerId: strategy.id,
         chainId,
       });
     },
@@ -81,7 +81,7 @@ export function ActivatePoints({
       publish({
         topic: "member",
         id: connectedAccount,
-        containerId: strategy.poolId,
+        containerId: strategy.id,
         type: "update",
         function: "deactivatePoints",
         chainId,

--- a/apps/web/components/CancelButton.tsx
+++ b/apps/web/components/CancelButton.tsx
@@ -37,7 +37,7 @@ function CancelButton({ proposalData }: Props) {
         type: "update",
         function: "cancelProposal",
         id: +proposalNumber,
-        containerId: proposalData.strategy.poolId,
+        containerId: proposalData.strategy.id,
         chainId: chainId,
       });
     },

--- a/apps/web/components/DisputeModal.tsx
+++ b/apps/web/components/DisputeModal.tsx
@@ -195,7 +195,7 @@ export const DisputeModal: FC<Props> = ({
           type: "update",
           function: "disputeProposal",
           id: proposalData.proposalNumber,
-            containerId: proposalData.strategy.id,
+          containerId: proposalData.strategy.id,
           chainId,
         });
       },

--- a/apps/web/components/DisputeModal.tsx
+++ b/apps/web/components/DisputeModal.tsx
@@ -102,7 +102,7 @@ export const DisputeModal: FC<Props> = ({
     changeScope: {
       topic: "proposal",
       id: proposalData?.proposalNumber,
-      containerId: proposalData?.strategy.poolId,
+      containerId: proposalData?.strategy.id,
       type: "update",
     },
     enabled: proposalData != null,
@@ -195,7 +195,7 @@ export const DisputeModal: FC<Props> = ({
           type: "update",
           function: "disputeProposal",
           id: proposalData.proposalNumber,
-          containerId: proposalData.strategy.poolId,
+            containerId: proposalData.strategy.id,
           chainId,
         });
       },
@@ -231,7 +231,7 @@ export const DisputeModal: FC<Props> = ({
         type: "update",
         function: "executeRuling",
         id: proposalData.proposalNumber,
-        containerId: proposalData.strategy.poolId,
+        containerId: proposalData.strategy.id,
         chainId,
       });
     },
@@ -253,7 +253,7 @@ export const DisputeModal: FC<Props> = ({
         type: "update",
         function: "rule",
         id: proposalData.proposalNumber,
-        containerId: proposalData.strategy.poolId,
+        containerId: proposalData.strategy.id,
         chainId,
       });
     },

--- a/apps/web/components/Forms/EditProposalForm.tsx
+++ b/apps/web/components/Forms/EditProposalForm.tsx
@@ -261,7 +261,7 @@ export const EditProposalForm = ({
         topic: "proposal",
         type: "update",
         function: "editProposal",
-        containerId: strategy.poolId,
+        containerId: strategy.id,
         id: proposal.proposalNumber.toString(), // proposalNumber is a bigint
         chainId,
       });

--- a/apps/web/components/Forms/PoolEditForm.tsx
+++ b/apps/web/components/Forms/PoolEditForm.tsx
@@ -391,7 +391,7 @@ export default function PoolEditForm({
         topic: "pool",
         function: "setPoolParams",
         type: "update",
-        id: strategy.poolId,
+        id: strategy.id,
         chainId: chainId,
       });
     },

--- a/apps/web/components/Forms/PoolForm.tsx
+++ b/apps/web/components/Forms/PoolForm.tsx
@@ -575,7 +575,7 @@ export function PoolForm({
         topic: "pool",
         function: "createPool",
         type: "add",
-        id: newPoolData._poolId.toString(), // Never propagate direct bigint outside of javascript environment
+        id: strategyAddress,
         containerId: communityAddr,
         chainId: chain.id,
       });

--- a/apps/web/components/Forms/ProposalForm.tsx
+++ b/apps/web/components/Forms/ProposalForm.tsx
@@ -214,7 +214,7 @@ export const ProposalForm = ({
         topic: "proposal",
         type: "update",
         function: "registerRecipient",
-        containerId: poolId,
+        containerId: strategy.id,
         id: proposalId.toString(), // proposalId is a bigint
         chainId,
       });

--- a/apps/web/components/PoolHeader.tsx
+++ b/apps/web/components/PoolHeader.tsx
@@ -168,7 +168,7 @@ export default function PoolHeader({
       changeScope: {
         topic: "pool",
         type: "update",
-        id: strategy.poolId,
+        id: strategy.id,
         chainId: chainId,
       },
     });
@@ -512,7 +512,7 @@ export default function PoolHeader({
         topic: "pool",
         function: "setPoolParams",
         type: "update",
-        id: strategy.poolId,
+        id: strategy.id,
         chainId: chainId,
       });
     },

--- a/apps/web/components/PoolMetrics.tsx
+++ b/apps/web/components/PoolMetrics.tsx
@@ -101,13 +101,13 @@ export const PoolMetrics: FC<PoolMetricsProps> = ({
     receiver: poolAddress,
     superToken: superToken?.address as Address,
     chainId,
-    containerId: poolId,
+    containerId: poolAddress,
   });
   const { currentFlowRateBn: directPoolFlowRateBn } = useSuperfluidStream({
     receiver: (streamReceiver ?? "") as Address,
     superToken: superToken?.address as Address,
     chainId,
-    containerId: streamReceiver ?? poolId,
+    containerId: poolAddress,
     sender: streamSender,
     includePoolMembers: false,
   });

--- a/apps/web/components/ProposalCard.tsx
+++ b/apps/web/components/ProposalCard.tsx
@@ -105,7 +105,7 @@ export type ProposalCardProps = {
   communityToken: Parameters<typeof useConvictionRead>[0]["tokenData"];
   inputHandler: (proposalId: string, value: bigint) => void;
   minThGtTotalEffPoints: boolean;
-  poolId: number;
+  poolAddress: string;
 };
 
 export type ProposalHandle = {
@@ -132,7 +132,7 @@ export const ProposalCard = forwardRef<ProposalHandle, ProposalCardProps>(
       memberPoolWeight,
       communityToken: tokenData,
       minThGtTotalEffPoints,
-      poolId,
+      poolAddress,
     },
     ref,
   ) => {
@@ -224,7 +224,7 @@ export const ProposalCard = forwardRef<ProposalHandle, ProposalCardProps>(
         {
           topic: "proposal",
           type: "update",
-          containerId: poolId,
+          containerId: poolAddress,
           id: proposalNumber,
         },
         (payload) => {
@@ -240,7 +240,7 @@ export const ProposalCard = forwardRef<ProposalHandle, ProposalCardProps>(
       return () => {
         unsubscribe(subscriptionId);
       };
-    }, [poolId, proposalNumber, subscribe, unsubscribe]);
+    }, [poolAddress, proposalNumber, subscribe, unsubscribe]);
 
     useImperativeHandle(
       ref,
@@ -308,7 +308,7 @@ export const ProposalCard = forwardRef<ProposalHandle, ProposalCardProps>(
       receiver: proposalData.streamingEscrow as Address,
       superToken: strategyConfig.superfluidToken as Address,
       chainId,
-      containerId: poolId,
+      containerId: poolAddress,
     });
     const currentFlowRateBn =
       liveCurrentFlowRateBn ?? subgraphCurrentFlowRateBn;

--- a/apps/web/components/Proposals.tsx
+++ b/apps/web/components/Proposals.tsx
@@ -175,11 +175,11 @@ export function Proposals({
       {
         topic: "member",
         id: wallet,
-        containerId: strategy.poolId,
+        containerId: strategy.id,
       },
       {
         topic: "proposal",
-        containerId: strategy.poolId,
+        containerId: strategy.id,
         function: "allocate",
       },
     ],
@@ -195,10 +195,10 @@ export function Proposals({
       changeScope: [
         {
           topic: "proposal",
-          containerId: strategy.poolId,
+          containerId: strategy.id,
           type: "update",
         },
-        { topic: "member", id: wallet, containerId: strategy.poolId },
+        { topic: "member", id: wallet, containerId: strategy.id },
       ],
       enabled: !!wallet,
     },
@@ -223,8 +223,8 @@ export function Proposals({
     !!memberData?.member?.memberCommunity?.[0]?.isRegistered;
   const { memberActivatedStrategy, memberActivatedPoints } =
     getMemberActivationState({
-    memberPower,
-    subgraphActivatedPoints: memberActivatedPointsFromSubgraph,
+      memberPower,
+      subgraphActivatedPoints: memberActivatedPointsFromSubgraph,
     });
 
   const [sortedProposals, setSortedProposals] = useState(strategy.proposals);
@@ -480,7 +480,7 @@ export function Proposals({
       publish({
         topic: "proposal",
         type: "update",
-        containerId: strategy.poolId,
+        containerId: strategy.id,
         function: "allocate",
       });
       if (toastId.current != null) {
@@ -866,7 +866,7 @@ export function Proposals({
               <Fragment key={proposalData.proposalNumber}>
                 <ProposalCard
                   proposalData={proposalData}
-                  poolId={Number(strategy.poolId)}
+                  poolAddress={strategy.id}
                   strategyConfig={strategy.config}
                   inputData={inputs[proposalData.id]}
                   stakedFilter={stakedFilters[proposalData.id]}
@@ -933,6 +933,7 @@ export function Proposals({
                       communityToken={strategy.registryCommunity.garden}
                       isPoolEnabled={strategy.isEnabled}
                       minThGtTotalEffPoints={minThGtTotalEffPoints}
+                      poolAddress={strategy.id}
                     />
                   </Fragment>
                 ))}
@@ -1034,8 +1035,7 @@ export function useProposalFilter<
     | null;
 
   const [sortBy, setSortBy] = useState<SortType>("mostConviction");
-  const [hasManualSortSelection, setHasManualSortSelection] =
-    useState(false);
+  const [hasManualSortSelection, setHasManualSortSelection] = useState(false);
 
   const filteredAndSorted = useMemo(() => {
     if (!sortBy) return filteredProposals;

--- a/apps/web/components/ProposalsModalSupport.tsx
+++ b/apps/web/components/ProposalsModalSupport.tsx
@@ -71,7 +71,7 @@ export type ProposalCardProps = {
     formatted: string;
   };
   isAllocationView: boolean;
-
+  poolAddress: string;
   memberActivatedPoints: bigint;
   memberPoolWeight?: number;
   executeDisabled: boolean;
@@ -105,7 +105,7 @@ export const ProposalsModalSupport = forwardRef<
       inputData,
       poolToken,
       isAllocationView,
-
+      poolAddress,
       memberActivatedPoints,
       memberPoolWeight,
       communityToken: tokenData,
@@ -212,7 +212,7 @@ export const ProposalsModalSupport = forwardRef<
       receiver: streamingEscrowAddress ?? "",
       superToken: superfluidTokenAddress ?? "",
       chainId,
-      containerId: proposalData.id,
+      containerId: poolAddress,
     });
     const currentFlowRateBn =
       liveCurrentFlowRateBn ?? subgraphCurrentFlowRateBn;


### PR DESCRIPTION
## Summary
- switch web pubsub container IDs from pool IDs to strategy addresses for proposal, member, and stream updates
- keep rebalance writes publishing the `stream` topic consistently from pool and proposal pages
- publish the same `stream` rebalance event from the rebalance keeper cron route after confirmed transactions

## Validation
- pnpm --filter web typecheck
