### PR TITLE
Fix Vercel preview branch history lookup auth in E2E workflow

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -248,19 +248,21 @@ jobs:
                   branch_history_query="${branch_history_query}&teamId=${VERCEL_TEAM_ID}"
                 fi
 
-                branch_history_response="$(curl -fsSL \
-                  -H "Authorization: ${VERCEL_TOKEN}" \
-                  "${base_api}${branch_history_query}")"
-
-                ready_branch_url="$(echo "${branch_history_response}" | jq -r --arg branch_alias "${branch_alias}" --arg sha "${PR_HEAD_SHA}" '
-                  [.deployments[]
-                    | select((.readyState // .state // "") == "READY")
-                    | select((.meta.branchAlias // "") == $branch_alias)
-                    | select((.meta.githubCommitSha // "") != $sha)
-                    | select((.url // "") != "")]
-                  | sort_by(.createdAt)
-                  | last
-                  | .url // empty')"
+                if branch_history_response="$(curl -fsSL \
+                  -H "Authorization: Bearer ${VERCEL_TOKEN}" \
+                  "${base_api}${branch_history_query}")"; then
+                  ready_branch_url="$(echo "${branch_history_response}" | jq -r --arg branch_alias "${branch_alias}" --arg sha "${PR_HEAD_SHA}" '
+                    [.deployments[]
+                      | select((.readyState // .state // "") == "READY")
+                      | select((.meta.branchAlias // "") == $branch_alias)
+                      | select((.meta.githubCommitSha // "") != $sha)
+                      | select((.url // "") != "")]
+                    | sort_by(.createdAt)
+                    | last
+                    | .url // empty')"
+                else
+                  echo "::warning::Unable to fetch Vercel branch deployment history; falling back to branch alias or configured fallback URL."
+                fi
               fi
 
               if [ -n "${ready_branch_url}" ]; then


### PR DESCRIPTION
### Motivation

- Prevent the E2E job from hitting a 403 when fetching Vercel branch history due to a missing `Bearer` prefix in the `Authorization` header.
- Ensure a failed branch-history lookup does not abort the preview URL resolution so the workflow can fall back to the branch alias or configured fallback URL.

### Description

- Updated the secondary branch-history request to use `-H "Authorization: Bearer ${VERCEL_TOKEN}"` to match the primary deployment lookup.
- Wrapped the `curl` branch-history request in an `if` guard so a non-200 fetch does not trigger `set -euo pipefail` and abort the step, and emit a warning when the fetch fails.
- Change applied to the E2E workflow file `/.github/workflows/e2e.yml` around the Vercel preview lookup logic.

### Testing

- Verified the workflow YAML parses with `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/e2e.yml"); puts "yaml ok"'` which succeeded.
- Validated all step `run` script syntax by extracting them and checking with `bash -n` (via the provided Ruby check), which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a189a6496ac832d80d8ae899ba6df1d)