### PR TITLE
Migrate Gardens Markee sign to v1.3 leaderboard

### DIFF
--- a/apps/web/components/MarkeeModal.tsx
+++ b/apps/web/components/MarkeeModal.tsx
@@ -11,7 +11,7 @@ import { MarkeeAbi } from "@/src/customAbis";
 import {
   fetchMarkeeLeaderboard,
   fetchMarkeeViews,
-  GARDENS_STRATEGY,
+  GARDENS_LEADERBOARD,
   MarkeeNetwork,
 } from "@/utils/markee";
 import { getTxMessage } from "@/utils/transactionMessages";
@@ -106,7 +106,7 @@ export default function MarkeeModal({
 
   const { writeAsync, isLoading: isPending } =
     useContractWriteWithConfirmations({
-      address: GARDENS_STRATEGY,
+      address: GARDENS_LEADERBOARD,
       abi: MarkeeAbi,
       functionName: "createMarkee",
       contractName: "TopDawgPartnerStrategy",
@@ -149,7 +149,7 @@ export default function MarkeeModal({
     if (!leaderboardOpen || leaderboard.length > 0) return;
     setLeaderboardLoading(true);
     setLeaderboardError(null);
-    fetchMarkeeLeaderboard(GARDENS_STRATEGY)
+    fetchMarkeeLeaderboard(GARDENS_LEADERBOARD)
       .then((entries) => {
         setLeaderboard(entries);
         const addresses = entries.map((e) => e.address);

--- a/apps/web/components/MarkeeSign.tsx
+++ b/apps/web/components/MarkeeSign.tsx
@@ -8,7 +8,7 @@ import { MarkeeAbi } from "@/src/customAbis";
 import {
   fetchMarkeeSignData,
   recordMarkeeView,
-  GARDENS_STRATEGY,
+  GARDENS_LEADERBOARD,
   MarkeeNetwork,
 } from "@/utils/markee";
 
@@ -58,7 +58,7 @@ export default function MarkeeSign() {
   const [totalViews, setTotalViews] = useState<number | null>(null);
 
   const { data: onchainMinPrice } = useContractRead({
-    address: GARDENS_STRATEGY,
+    address: GARDENS_LEADERBOARD,
     abi: MarkeeAbi,
     functionName: "minimumPrice",
     chainId: MarkeeNetwork.id,
@@ -68,7 +68,7 @@ export default function MarkeeSign() {
     setLoading(true);
     setLoadError(null);
     try {
-      const strategy = await fetchMarkeeSignData(GARDENS_STRATEGY);
+      const strategy = await fetchMarkeeSignData(GARDENS_LEADERBOARD);
       const markee = strategy?.markees?.[0];
       const subgraphMinPrice = BigInt(strategy?.minimumPrice ?? 0);
       const onchainMinPriceValue =

--- a/apps/web/utils/markee.ts
+++ b/apps/web/utils/markee.ts
@@ -1,11 +1,9 @@
 import { Address, createPublicClient, http } from "viem";
 import { base } from "viem/chains";
+import { chainConfigMap } from "@/configs/chains";
 
 export const GARDENS_LEADERBOARD =
   "0x2768BC6e90266248BD8bCF5401C36D8049CdF671" as Address;
-
-// Keep old name as alias so any remaining imports still resolve
-export const GARDENS_STRATEGY = GARDENS_LEADERBOARD;
 
 export const MarkeeNetwork = base;
 
@@ -61,7 +59,8 @@ const MARKEE_READ_ABI = [
   },
 ] as const;
 
-const client = createPublicClient({ chain: base, transport: http() });
+const rpc = chainConfigMap[MarkeeNetwork.id].rpcUrl;
+const client = createPublicClient({ chain: base, transport: http(rpc) });
 
 export async function fetchMarkeeSignData(leaderboardAddress: Address) {
   const [addresses, funds] = await client.readContract({
@@ -69,7 +68,7 @@ export async function fetchMarkeeSignData(leaderboardAddress: Address) {
     abi: LEADERBOARD_ABI,
     functionName: "getTopMarkees",
     args: [1n],
-  }) as [readonly `0x${string}`[], readonly bigint[]];
+  });
 
   const minimumPrice = await client.readContract({
     address: leaderboardAddress,
@@ -90,28 +89,32 @@ export async function fetchMarkeeSignData(leaderboardAddress: Address) {
     allowFailure: true,
   });
 
-  const message = results[0].status === "success" ? (results[0].result as string) : "";
-  const name = results[1].status === "success" ? (results[1].result as string) : "";
+  const message =
+    results[0].status === "success" ? (results[0].result as string) : "";
+  const name =
+    results[1].status === "success" ? (results[1].result as string) : "";
 
   return {
     minimumPrice: minimumPrice.toString(),
-    markees: [{
-      id: topAddr.toLowerCase(),
-      address: topAddr.toLowerCase(),
-      message,
-      name,
-      totalFundsAdded: (funds[0] ?? 0n).toString(),
-    }] as MarkeeEntry[],
+    markees: [
+      {
+        id: topAddr.toLowerCase(),
+        address: topAddr.toLowerCase(),
+        message,
+        name,
+        totalFundsAdded: (funds[0] ?? 0n).toString(),
+      },
+    ] as MarkeeEntry[],
   };
 }
 
 export async function fetchMarkeeLeaderboard(leaderboardAddress: Address) {
-  const [addresses, funds] = await client.readContract({
+  const [addresses, funds] = (await client.readContract({
     address: leaderboardAddress,
     abi: LEADERBOARD_ABI,
     functionName: "getTopMarkees",
     args: [10n],
-  }) as [readonly `0x${string}`[], readonly bigint[]];
+  })) as [readonly `0x${string}`[], readonly bigint[]];
 
   if (!addresses.length) return [] as MarkeeEntry[];
 
@@ -120,14 +123,23 @@ export async function fetchMarkeeLeaderboard(leaderboardAddress: Address) {
     { address: addr, abi: MARKEE_READ_ABI, functionName: "name" as const },
   ]);
 
-  const results = await client.multicall({ contracts: markeeCalls, allowFailure: true });
+  const results = await client.multicall({
+    contracts: markeeCalls,
+    allowFailure: true,
+  });
 
   return addresses
     .map((addr, i) => ({
       id: addr.toLowerCase(),
       address: addr.toLowerCase(),
-      message: results[i * 2].status === "success" ? (results[i * 2].result as string) : "",
-      name: results[i * 2 + 1].status === "success" ? (results[i * 2 + 1].result as string) : "",
+      message:
+        results[i * 2].status === "success" ?
+          (results[i * 2].result as string)
+        : "",
+      name:
+        results[i * 2 + 1].status === "success" ?
+          (results[i * 2 + 1].result as string)
+        : "",
       totalFundsAdded: (funds[i] ?? 0n).toString(),
     }))
     .filter((entry) => entry.message.trim() !== "") as MarkeeEntry[];

--- a/apps/web/utils/markee.ts
+++ b/apps/web/utils/markee.ts
@@ -114,7 +114,7 @@ export async function fetchMarkeeLeaderboard(leaderboardAddress: Address) {
     args: [10n],
   });
 
-  if (!addresses.length) return [] as MarkeeEntry[];
+  if (!addresses.length) return [];
 
   const markeeCalls = addresses.flatMap((addr) => [
     { address: addr, abi: MARKEE_READ_ABI, functionName: "message" as const },
@@ -130,14 +130,15 @@ export async function fetchMarkeeLeaderboard(leaderboardAddress: Address) {
     .map((addr, i) => ({
       id: addr.toLowerCase(),
       address: addr.toLowerCase(),
-      message: results[i * 2].status === "success" ? results[i * 2].result : "",
+      message:
+        results[i * 2].status === "success" ? results[i * 2].result ?? "" : "",
       name:
         results[i * 2 + 1].status === "success" ?
-          results[i * 2 + 1].result
+          results[i * 2 + 1].result ?? ""
         : "",
       totalFundsAdded: (funds[i] ?? 0n).toString(),
     }))
-    .filter((entry) => entry.message?.trim() !== "");
+    .filter((entry) => entry.message.trim() !== "");
 }
 
 // ─── View Tracking ────────────────────────────────────────────────────────────

--- a/apps/web/utils/markee.ts
+++ b/apps/web/utils/markee.ts
@@ -89,10 +89,8 @@ export async function fetchMarkeeSignData(leaderboardAddress: Address) {
     allowFailure: true,
   });
 
-  const message =
-    results[0].status === "success" ? (results[0].result as string) : "";
-  const name =
-    results[1].status === "success" ? (results[1].result as string) : "";
+  const message = results[0].status === "success" ? results[0].result : "";
+  const name = results[1].status === "success" ? results[1].result : "";
 
   return {
     minimumPrice: minimumPrice.toString(),
@@ -109,12 +107,12 @@ export async function fetchMarkeeSignData(leaderboardAddress: Address) {
 }
 
 export async function fetchMarkeeLeaderboard(leaderboardAddress: Address) {
-  const [addresses, funds] = (await client.readContract({
+  const [addresses, funds] = await client.readContract({
     address: leaderboardAddress,
     abi: LEADERBOARD_ABI,
     functionName: "getTopMarkees",
     args: [10n],
-  })) as [readonly `0x${string}`[], readonly bigint[]];
+  });
 
   if (!addresses.length) return [] as MarkeeEntry[];
 
@@ -132,17 +130,14 @@ export async function fetchMarkeeLeaderboard(leaderboardAddress: Address) {
     .map((addr, i) => ({
       id: addr.toLowerCase(),
       address: addr.toLowerCase(),
-      message:
-        results[i * 2].status === "success" ?
-          (results[i * 2].result as string)
-        : "",
+      message: results[i * 2].status === "success" ? results[i * 2].result : "",
       name:
         results[i * 2 + 1].status === "success" ?
-          (results[i * 2 + 1].result as string)
+          results[i * 2 + 1].result
         : "",
       totalFundsAdded: (funds[i] ?? 0n).toString(),
     }))
-    .filter((entry) => entry.message.trim() !== "") as MarkeeEntry[];
+    .filter((entry) => entry.message?.trim() !== "");
 }
 
 // ─── View Tracking ────────────────────────────────────────────────────────────

--- a/apps/web/utils/markee.ts
+++ b/apps/web/utils/markee.ts
@@ -122,13 +122,15 @@ export async function fetchMarkeeLeaderboard(leaderboardAddress: Address) {
 
   const results = await client.multicall({ contracts: markeeCalls, allowFailure: true });
 
-  return addresses.map((addr, i) => ({
-    id: addr.toLowerCase(),
-    address: addr.toLowerCase(),
-    message: results[i * 2].status === "success" ? (results[i * 2].result as string) : "",
-    name: results[i * 2 + 1].status === "success" ? (results[i * 2 + 1].result as string) : "",
-    totalFundsAdded: (funds[i] ?? 0n).toString(),
-  })) as MarkeeEntry[];
+  return addresses
+    .map((addr, i) => ({
+      id: addr.toLowerCase(),
+      address: addr.toLowerCase(),
+      message: results[i * 2].status === "success" ? (results[i * 2].result as string) : "",
+      name: results[i * 2 + 1].status === "success" ? (results[i * 2 + 1].result as string) : "",
+      totalFundsAdded: (funds[i] ?? 0n).toString(),
+    }))
+    .filter((entry) => entry.message.trim() !== "") as MarkeeEntry[];
 }
 
 // ─── View Tracking ────────────────────────────────────────────────────────────

--- a/apps/web/utils/markee.ts
+++ b/apps/web/utils/markee.ts
@@ -1,19 +1,11 @@
-import { Address } from "viem";
+import { Address, createPublicClient, http } from "viem";
 import { base } from "viem/chains";
 
-const MARKEE_SUBGRAPH_ID = "8kMCKUHSY7o6sQbsvufeLVo8PifxrsnagjVTMGcs6KdF";
-const SUBGRAPH_GATEWAY_KEY = process.env.NEXT_PUBLIC_SUBGRAPH_KEY;
-const MARKEE_STUDIO_URL =
-  "https://api.studio.thegraph.com/query/1742437/markee-base/version/latest";
-const MARKEE_GATEWAY_URL =
-  SUBGRAPH_GATEWAY_KEY ?
-    `https://gateway.thegraph.com/api/${SUBGRAPH_GATEWAY_KEY}/subgraphs/id/${MARKEE_SUBGRAPH_ID}`
-  : undefined;
+export const GARDENS_LEADERBOARD =
+  "0x2768BC6e90266248BD8bCF5401C36D8049CdF671" as Address;
 
-export const MARKEE_SUBGRAPH_URL = MARKEE_GATEWAY_URL ?? MARKEE_STUDIO_URL;
-
-export const GARDENS_STRATEGY =
-  "0x346419315740F085Ba14cA7239D82105a9a2BDBE" as Address;
+// Keep old name as alias so any remaining imports still resolve
+export const GARDENS_STRATEGY = GARDENS_LEADERBOARD;
 
 export const MarkeeNetwork = base;
 
@@ -25,89 +17,129 @@ export type MarkeeEntry = {
   totalFundsAdded: string;
 };
 
-type MarkeeSubgraphResponse = {
-  data?: {
-    topDawgPartnerStrategy?: {
-      minimumPrice?: string;
-      markees?: MarkeeEntry[];
-    } | null;
-  };
-  errors?: unknown;
-};
+const LEADERBOARD_ABI = [
+  {
+    inputs: [{ name: "limit", type: "uint256" }],
+    name: "getTopMarkees",
+    outputs: [
+      { name: "topAddresses", type: "address[]" },
+      { name: "topFunds", type: "uint256[]" },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "minimumPrice",
+    outputs: [{ name: "", type: "uint256" }],
+    stateMutability: "view",
+    type: "function",
+  },
+] as const;
 
-async function postMarkeeQuery(query: string): Promise<MarkeeSubgraphResponse> {
-  const urls = [MARKEE_GATEWAY_URL, MARKEE_STUDIO_URL].filter(
-    (url): url is string => Boolean(url),
-  );
-  let lastError: Error | undefined;
-  for (const url of urls) {
-    try {
-      const response = await fetch(url, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ query }),
-      });
-      if (!response.ok) {
-        throw new Error(
-          `Subgraph request failed with ${response.status} at ${url}`,
-        );
-      }
-      const result = (await response.json()) as MarkeeSubgraphResponse;
-      if (result.errors) {
-        throw new Error(
-          `Subgraph returned GraphQL errors at ${url}: ${JSON.stringify(result.errors)}`,
-        );
-      }
-      return result;
-    } catch (error) {
-      lastError = error as Error;
-    }
+const MARKEE_READ_ABI = [
+  {
+    inputs: [],
+    name: "message",
+    outputs: [{ name: "", type: "string" }],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "name",
+    outputs: [{ name: "", type: "string" }],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "totalFundsAdded",
+    outputs: [{ name: "", type: "uint256" }],
+    stateMutability: "view",
+    type: "function",
+  },
+] as const;
+
+const client = createPublicClient({ chain: base, transport: http() });
+
+export async function fetchMarkeeSignData(leaderboardAddress: Address) {
+  const [addresses, funds] = await client.readContract({
+    address: leaderboardAddress,
+    abi: LEADERBOARD_ABI,
+    functionName: "getTopMarkees",
+    args: [1n],
+  }) as [readonly `0x${string}`[], readonly bigint[]];
+
+  const minimumPrice = await client.readContract({
+    address: leaderboardAddress,
+    abi: LEADERBOARD_ABI,
+    functionName: "minimumPrice",
+  });
+
+  if (!addresses[0]) {
+    return { minimumPrice: minimumPrice.toString(), markees: [] };
   }
-  throw lastError ?? new Error("Failed to query Markee subgraph");
+
+  const topAddr = addresses[0];
+  const results = await client.multicall({
+    contracts: [
+      { address: topAddr, abi: MARKEE_READ_ABI, functionName: "message" },
+      { address: topAddr, abi: MARKEE_READ_ABI, functionName: "name" },
+    ],
+    allowFailure: true,
+  });
+
+  const message = results[0].status === "success" ? (results[0].result as string) : "";
+  const name = results[1].status === "success" ? (results[1].result as string) : "";
+
+  return {
+    minimumPrice: minimumPrice.toString(),
+    markees: [{
+      id: topAddr.toLowerCase(),
+      address: topAddr.toLowerCase(),
+      message,
+      name,
+      totalFundsAdded: (funds[0] ?? 0n).toString(),
+    }] as MarkeeEntry[],
+  };
 }
 
-export async function fetchMarkeeSignData(strategyAddress: Address) {
-  const strategyId = strategyAddress.toLowerCase();
-  const result = await postMarkeeQuery(`{
-    topDawgPartnerStrategy(id: "${strategyId}") {
-      minimumPrice
-      markees(first: 1, orderBy: totalFundsAdded, orderDirection: desc) {
-        id
-        address
-        message
-        name
-        totalFundsAdded
-      }
-    }
-  }`);
-  return result.data?.topDawgPartnerStrategy ?? null;
-}
+export async function fetchMarkeeLeaderboard(leaderboardAddress: Address) {
+  const [addresses, funds] = await client.readContract({
+    address: leaderboardAddress,
+    abi: LEADERBOARD_ABI,
+    functionName: "getTopMarkees",
+    args: [10n],
+  }) as [readonly `0x${string}`[], readonly bigint[]];
 
-export async function fetchMarkeeLeaderboard(strategyAddress: Address) {
-  const strategyId = strategyAddress.toLowerCase();
-  const result = await postMarkeeQuery(`{
-    topDawgPartnerStrategy(id: "${strategyId}") {
-      markees(first: 10, orderBy: totalFundsAdded, orderDirection: desc) {
-        id
-        address
-        message
-        name
-        totalFundsAdded
-      }
-    }
-  }`);
-  return result.data?.topDawgPartnerStrategy?.markees ?? [];
+  if (!addresses.length) return [] as MarkeeEntry[];
+
+  const markeeCalls = addresses.flatMap((addr) => [
+    { address: addr, abi: MARKEE_READ_ABI, functionName: "message" as const },
+    { address: addr, abi: MARKEE_READ_ABI, functionName: "name" as const },
+  ]);
+
+  const results = await client.multicall({ contracts: markeeCalls, allowFailure: true });
+
+  return addresses.map((addr, i) => ({
+    id: addr.toLowerCase(),
+    address: addr.toLowerCase(),
+    message: results[i * 2].status === "success" ? (results[i * 2].result as string) : "",
+    name: results[i * 2 + 1].status === "success" ? (results[i * 2 + 1].result as string) : "",
+    totalFundsAdded: (funds[i] ?? 0n).toString(),
+  })) as MarkeeEntry[];
 }
 
 // ─── View Tracking ────────────────────────────────────────────────────────────
 // Centralized on markee.xyz. Views are keyed by individual markee contract
-// address (markee.address), not the strategy address — matching markee.xyz.
+// address (markee.address), not the leaderboard address — matching markee.xyz.
 
 const MARKEE_VIEWS_URL = "https://www.markee.xyz/api/views";
 
 /**
  * Record a view for an individual markee contract address + current message.
- * Pass markee.address (the individual markee contract), not the strategy address.
+ * Pass markee.address (the individual markee contract), not the leaderboard address.
  * Fire-and-forget safe — errors are swallowed by the caller.
  */
 export async function recordMarkeeView(


### PR DESCRIPTION
## Summary

- Replaces The Graph subgraph queries with direct RPC calls (viem) against the v1.3 Gardens leaderboard at `0x2768BC6e90266248BD8bCF5401C36D8049CdF671`
- `fetchMarkeeSignData` and `fetchMarkeeLeaderboard` now use `getTopMarkees()` + multicall instead of GraphQL
- Removes the `NEXT_PUBLIC_SUBGRAPH_KEY` dependency for the Markee sign component
- `GARDENS_STRATEGY` kept as a re-export alias; new primary export is `GARDENS_LEADERBOARD`
- View tracking via `markee.xyz/api/views` is unchanged

## Test plan

- [x] Markee sign displays current top message on the Gardens campaigns page
- [x] Clicking the sign opens the modal with the leaderboard populated
- [ ] Submitting a new markee purchase calls `createMarkee` on the v1.3 leaderboard and updates the sign (📝would need a testnet env)
- [x] View count increments on page load and is displayed in the sign corner