### PR TITLE
fix(web): use governance token for capped signaling pool metadata

### DIFF
--- a/apps/web/components/PoolHeader.tsx
+++ b/apps/web/components/PoolHeader.tsx
@@ -69,6 +69,7 @@ import {
   MAX_RATIO_CONSTANT,
   roundToSignificant,
 } from "@/utils/numbers";
+import { resolvePoolHeaderTokens } from "@/utils/poolHeaderTokens";
 import { shortenAddress } from "@/utils/text";
 
 type Props = {
@@ -210,8 +211,23 @@ export default function PoolHeader({
       )
     : "0";
 
-  const maxVotingWeight =
-    poolToken ? formatTokenAmount(maxAmount, poolToken.decimals) : 0;
+  const gardenToken = strategy.registryCommunity.garden;
+
+  const governanceToken = {
+    address: (gardenToken.address ?? gardenToken.id) as Address,
+    symbol: gardenToken.symbol,
+    decimals: communityGovTokenDecimals ?? 18,
+  };
+
+  // Signaling pools have no funding token, so the pool configuration describes
+  // the governance token instead.
+  const { votingToken, configToken } = resolvePoolHeaderTokens({
+    poolType: PoolTypes[strategy.config.proposalType],
+    governanceToken,
+    poolToken,
+  });
+
+  const maxVotingWeight = formatTokenAmount(maxAmount, votingToken.decimals);
 
   const spendingLimit =
     (strategy.config.maxRatio / CV_SCALE_PRECISION) *
@@ -312,7 +328,7 @@ export default function PoolHeader({
     },
     {
       label: "Max voting weight",
-      value: `${maxVotingWeight} ${poolToken?.symbol}`,
+      value: `${maxVotingWeight} ${votingToken.symbol}`,
       info: "Staking above this specified limit won’t increase your voting weight.",
     },
     {
@@ -352,17 +368,24 @@ export default function PoolHeader({
     {
       label: "Token",
       info:
-        PoolTypes[proposalType] === "streaming" ?
+        PoolTypes[proposalType] === "signaling" ?
+          "The community governance token used to determine voting power."
+        : PoolTypes[proposalType] === "streaming" ?
           "The token used in this pool for streaming."
         : "The token used in this pool to fund proposals.",
       value: (
         <div className="flex items-center">
+          {/*
+            `configToken` is always defined for signaling pools. For funding and
+            streaming pools it resolves asynchronously, so keep passing it
+            through and let `EthAddress` show its loading state meanwhile.
+          */}
           <EthAddress
-            address={poolToken?.address as Address}
+            address={configToken?.address as Address}
             shortenAddress={true}
             icon={false}
             actions="none"
-            label={poolToken?.symbol}
+            label={configToken?.symbol}
           />
           {superToken && (
             <div

--- a/apps/web/utils/poolHeaderTokens.test.ts
+++ b/apps/web/utils/poolHeaderTokens.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+
+import { PoolHeaderToken, resolvePoolHeaderTokens } from "./poolHeaderTokens";
+
+const RWAGMI: PoolHeaderToken = {
+  address: "0xb200000000000000000000bf0548ab2ebd00ba5e",
+  symbol: "RWAGMI",
+  decimals: 18,
+};
+
+const GOV: PoolHeaderToken = {
+  address: "0x1111111111111111111111111111111111111111",
+  symbol: "GOV",
+  decimals: 18,
+};
+
+const USDC: PoolHeaderToken = {
+  address: "0x2222222222222222222222222222222222222222",
+  symbol: "USDC",
+  decimals: 6,
+};
+
+describe("resolvePoolHeaderTokens", () => {
+  it("uses the governance token for capped signaling pools", () => {
+    const { configToken, votingToken } = resolvePoolHeaderTokens({
+      poolType: "signaling",
+      governanceToken: RWAGMI,
+      poolToken: undefined,
+    });
+
+    expect(configToken).toBe(RWAGMI);
+    expect(votingToken).toBe(RWAGMI);
+  });
+
+  it("keeps the funding token separate from the voting token", () => {
+    const { configToken, votingToken } = resolvePoolHeaderTokens({
+      poolType: "funding",
+      governanceToken: GOV,
+      poolToken: USDC,
+    });
+
+    expect(configToken).toBe(USDC);
+    expect(configToken?.decimals).toBe(6);
+    expect(votingToken).toBe(GOV);
+    expect(votingToken.decimals).toBe(18);
+  });
+
+  it("shows the stream token for streaming pools", () => {
+    const { configToken, votingToken } = resolvePoolHeaderTokens({
+      poolType: "streaming",
+      governanceToken: GOV,
+      poolToken: USDC,
+    });
+
+    expect(configToken).toBe(USDC);
+    expect(votingToken).toBe(GOV);
+  });
+
+  it("never depends on poolToken for signaling pools", () => {
+    const { configToken } = resolvePoolHeaderTokens({
+      poolType: "signaling",
+      governanceToken: RWAGMI,
+      poolToken: undefined,
+    });
+
+    // The RWAGMI regression: an undefined config token renders as a permanent
+    // loading spinner in `EthAddress`.
+    expect(configToken).toBeDefined();
+    expect(configToken?.address).toBe(RWAGMI.address);
+    expect(configToken?.symbol).toBe("RWAGMI");
+  });
+});

--- a/apps/web/utils/poolHeaderTokens.ts
+++ b/apps/web/utils/poolHeaderTokens.ts
@@ -1,0 +1,44 @@
+import { Address } from "viem";
+
+import type { PoolTypes } from "@/types";
+
+export type PoolType = (typeof PoolTypes)[string];
+
+export type PoolHeaderToken = {
+  address: Address;
+  symbol: string;
+  decimals: number;
+};
+
+type ResolvePoolHeaderTokensArgs = {
+  poolType: PoolType | undefined;
+  /** Community token that determines voting power (`registryCommunity.garden`). */
+  governanceToken: PoolHeaderToken;
+  /** Asset held / spent / streamed by the strategy. Undefined for signaling pools. */
+  poolToken?: PoolHeaderToken;
+};
+
+type PoolHeaderTokens = {
+  /** Token that denominates voting weight. Always the governance token. */
+  votingToken: PoolHeaderToken;
+  /** Token whose identity is shown in the pool configuration. */
+  configToken: PoolHeaderToken | undefined;
+};
+
+/**
+ * Picks the tokens the pool header should display.
+ *
+ * Signaling pools have no funding token, so their configuration describes the
+ * governance token instead. Voting weight is always denominated in the
+ * governance token, since `pointConfig.maxAmount` is stored using its decimals.
+ */
+export function resolvePoolHeaderTokens({
+  poolType,
+  governanceToken,
+  poolToken,
+}: ResolvePoolHeaderTokensArgs): PoolHeaderTokens {
+  return {
+    votingToken: governanceToken,
+    configToken: poolType === "signaling" ? governanceToken : poolToken,
+  };
+}


### PR DESCRIPTION
## Problem

Capped signaling pools render an indefinite loading spinner in the pool `Token` field.

`usePoolToken` intentionally does not resolve a pool/funding token for signaling pools:

```ts
enabled: !!strategy && poolType !== "signaling" && !!poolTokenAddr
```

But `PoolHeader` keeps the `Token` and `Max voting weight` rows for **capped** signaling pools (non-capped signaling filters them out). So it passes an undefined `poolToken?.address` to `EthAddress`, whose missing-address fallback is a `LoadingSpinner`.

The "infinite loading" is therefore a permanently rendered spinner, not a pending request.

## Fix

Distinguish the community **governance** token from the pool **funding** token:

- Signaling pools display `registryCommunity.garden` in the pool configuration.
- `Max voting weight` is formatted with the governance token's decimals and symbol.
- Funding and streaming pools continue to display their configured pool token.
- The `Token` tooltip is now accurate for signaling pools.

Token selection is extracted into a small pure helper (`utils/poolHeaderTokens.ts`) so the regression is unit-testable without mounting `PoolHeader`.

## Why

Voting weight is denominated in the governance token. Pool creation already stores `pointConfig.maxAmount` using `governanceToken.decimals`:

```ts
pointConfig: { maxAmount: parseUnits(maxAmountStr, governanceToken.decimals) }
```

The previous code formatted that value with `poolToken.decimals`, which was wrong for signaling pools **and** for capped funding pools whose funding token has different decimals from the governance token (e.g. USDC 6 vs GOV 18).

## Regression case

Base pool 194 (`/gardens/8453/0x6ad9acd7fc1868f82101331dd66dd0f5bace09cd/0xc8020af2a459b693c67cc56fe0fda7febfab6ee6`), signaling + capped, governance token RWAGMI.

Subgraph state confirms the inputs:

```
config.proposalType: 0   (signaling)
config.pointSystem:  1   (capped)
config.maxAmount:    1000000000000000000000000000
garden: RWAGMI, 18 decimals, 0xb200000000000000000000bf0548ab2ebd00ba5e
```

| | Before | After |
|---|---|---|
| Token | permanent spinner | `RWAGMI` / `0xb200…ba5e` |
| Max voting weight | `0 undefined` | `1,000,000,000 RWAGMI` |

## Notes on scope

- `EthAddress` is deliberately **not** changed. Its spinner fallback is legitimate for callers that resolve addresses asynchronously — which is still the case for funding/streaming pools, where `poolToken` loads after `PoolHeader` first renders. The bug was the caller passing an address that would never exist.
- The `Token` label is kept as-is, since `filteredPoolConfig` currently keys off label strings. Renaming it to `Voting token` for signaling pools would change filtering behaviour and is better done alongside replacing label-based filtering with stable IDs.
- No contracts, subgraph mappings/schema, `usePoolToken`, `usePoolAmount`, or lockfile changes.

## Testing

Run from `apps/web`:

- `pnpm test:unit` — 18 files / 102 tests pass, including 4 new cases
- `pnpm typecheck` — clean
- `pnpm lint` — clean (one pre-existing unrelated warning in `campaigns/[campaignId]/page.tsx`)
- `pnpm build` — production build passes

New coverage in `utils/poolHeaderTokens.test.ts`:

- capped signaling pool resolves to the governance token
- funding pool keeps funding token (USDC/6) separate from voting token (GOV/18)
- streaming pool token selection
- signaling pool never depends on `poolToken` (`configToken` is always defined)
