### PR TITLE
fix(web): hide token row on signaling pools

### DIFF
--- a/apps/web/components/PoolHeader.tsx
+++ b/apps/web/components/PoolHeader.tsx
@@ -69,6 +69,7 @@ import {
   MAX_RATIO_CONSTANT,
   roundToSignificant,
 } from "@/utils/numbers";
+import { getHiddenPoolConfigLabels } from "@/utils/poolConfigLabels";
 import { shortenAddress } from "@/utils/text";
 
 type Props = {
@@ -210,8 +211,12 @@ export default function PoolHeader({
       )
     : "0";
 
-  const maxVotingWeight =
-    poolToken ? formatTokenAmount(maxAmount, poolToken.decimals) : 0;
+  // Voting weight is denominated in the community governance token, and pool
+  // creation stores `pointConfig.maxAmount` with that token's decimals.
+  const maxVotingWeight = formatTokenAmount(
+    maxAmount,
+    communityGovTokenDecimals ?? 18,
+  );
 
   const spendingLimit =
     (strategy.config.maxRatio / CV_SCALE_PRECISION) *
@@ -312,7 +317,7 @@ export default function PoolHeader({
     },
     {
       label: "Max voting weight",
-      value: `${maxVotingWeight} ${poolToken?.symbol}`,
+      value: `${maxVotingWeight} ${strategy.registryCommunity.garden.symbol}`,
       info: "Staking above this specified limit won’t increase your voting weight.",
     },
     {
@@ -411,32 +416,16 @@ export default function PoolHeader({
     : []),
   ] as const;
 
-  const filteredPoolConfig =
-    (
-      PoolTypes[proposalType] === "signaling" &&
-      PointSystems[pointSystem] !== "capped"
-    ) ?
-      poolConfig.filter((config) => {
-        const filter: (typeof poolConfig)[number]["label"][] = [
-          "Spending limit",
-          "Min threshold",
-          "Min conviction",
-          "Max voting weight",
-          "Token",
-        ];
-        return config.value != null && !filter.includes(config.label);
-      })
-    : PoolTypes[proposalType] === "signaling" ?
-      poolConfig.filter((config) => {
-        const filteredLabels: (typeof poolConfig)[number]["label"][] = [
-          "Spending limit",
-          "Min threshold",
-          "Min conviction",
-        ];
-        return config.value != null && !filteredLabels.includes(config.label);
-      })
-    : PointSystems[pointSystem] === "capped" ? poolConfig
-    : poolConfig.filter((config) => config.label !== "Max voting weight");
+  const hiddenPoolConfigLabels = getHiddenPoolConfigLabels({
+    poolType: PoolTypes[proposalType],
+    pointSystem: PointSystems[pointSystem],
+  });
+
+  const filteredPoolConfig = poolConfig.filter(
+    (config) =>
+      !hiddenPoolConfigLabels.includes(config.label) &&
+      (PoolTypes[proposalType] !== "signaling" || config.value != null),
+  );
 
   const { write: rejectPoolWrite } = useContractWriteWithConfirmations({
     address: communityAddr,

--- a/apps/web/utils/poolConfigLabels.test.ts
+++ b/apps/web/utils/poolConfigLabels.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+
+import { getHiddenPoolConfigLabels } from "./poolConfigLabels";
+
+describe("getHiddenPoolConfigLabels", () => {
+  it("hides the token row on capped signaling pools", () => {
+    const hidden = getHiddenPoolConfigLabels({
+      poolType: "signaling",
+      pointSystem: "capped",
+    });
+
+    expect(hidden).toContain("Token");
+    // Capped is the one point system where the cap is meaningful.
+    expect(hidden).not.toContain("Max voting weight");
+  });
+
+  it("hides the token and voting weight rows on uncapped signaling pools", () => {
+    const hidden = getHiddenPoolConfigLabels({
+      poolType: "signaling",
+      pointSystem: "unlimited",
+    });
+
+    expect(hidden).toEqual(
+      expect.arrayContaining([
+        "Spending limit",
+        "Min threshold",
+        "Min conviction",
+        "Token",
+        "Max voting weight",
+      ]),
+    );
+  });
+
+  it("keeps the token row on funding and streaming pools", () => {
+    for (const poolType of ["funding", "streaming"] as const) {
+      const hidden = getHiddenPoolConfigLabels({
+        poolType,
+        pointSystem: "capped",
+      });
+
+      expect(hidden).toEqual([]);
+    }
+  });
+
+  it("hides only the voting weight row on uncapped funding pools", () => {
+    expect(
+      getHiddenPoolConfigLabels({
+        poolType: "funding",
+        pointSystem: "quadratic",
+      }),
+    ).toEqual(["Max voting weight"]);
+  });
+});

--- a/apps/web/utils/poolConfigLabels.ts
+++ b/apps/web/utils/poolConfigLabels.ts
@@ -1,0 +1,35 @@
+import type { PointSystems, PoolTypes } from "@/types";
+
+type PoolType = (typeof PoolTypes)[string];
+type PointSystem = (typeof PointSystems)[string];
+
+type HiddenPoolConfigLabelsArgs = {
+  poolType: PoolType | undefined;
+  pointSystem: PointSystem | undefined;
+};
+
+/**
+ * Pool settings rows that don't apply to the given pool.
+ *
+ * Signaling pools distribute nothing, so the funding-oriented rows are dropped.
+ * That includes `Token`: a signaling pool has no pool token, only the community
+ * governance token that voting weight is denominated in, and labelling that as
+ * the pool token is misleading.
+ *
+ * `Max voting weight` only means something when the point system caps it.
+ */
+export function getHiddenPoolConfigLabels({
+  poolType,
+  pointSystem,
+}: HiddenPoolConfigLabelsArgs): string[] {
+  const hidden =
+    poolType === "signaling" ?
+      ["Spending limit", "Min threshold", "Min conviction", "Token"]
+    : [];
+
+  if (pointSystem !== "capped") {
+    hidden.push("Max voting weight");
+  }
+
+  return hidden;
+}


### PR DESCRIPTION
Supersedes #950, reworked to follow @Corantin's review: hide the token in signaling pools rather than showing the governance token there.

## Problem

Capped signaling pools render a permanent loading spinner in the pool `Token` field.

`usePoolToken` intentionally does not resolve a token for signaling pools:

```ts
enabled: !!strategy && poolType !== "signaling" && !!poolTokenAddr
```

But `PoolHeader` kept the `Token` and `Max voting weight` rows for **capped** signaling pools (non-capped signaling already filtered both out). So it passed an undefined `poolToken?.address` to `EthAddress`, whose missing-address fallback is a `LoadingSpinner`. The "infinite loading" is a permanently rendered spinner, not a pending request.

`Max voting weight` had the same root cause and rendered `0 undefined`.

## Fix

**1. Hide the `Token` row on all signaling pools.** A signaling pool has no pool token — only the community governance token that voting weight is denominated in — and labelling that as the pool token would be confusing. This makes capped signaling consistent with non-capped signaling.

**2. Format `Max voting weight` with the governance token.** Pool creation already stores `pointConfig.maxAmount` using the governance token's decimals:

```ts
pointConfig: { maxAmount: parseUnits(maxAmountStr, governanceToken.decimals) }
```

The previous code formatted that value with `poolToken.decimals`, which was wrong for signaling pools **and** for capped funding pools whose funding token has different decimals from the governance token (e.g. USDC 6 vs GOV 18).

**3. Extract the row filtering** into a pure `utils/poolConfigLabels.ts` helper. The previous four-way nested ternary was where the capped-signaling case slipped through; the helper makes the rule explicit and unit-testable without mounting `PoolHeader`.

## Regression case

Base pool 194 (`/gardens/8453/0x6ad9acd7fc1868f82101331dd66dd0f5bace09cd/0xc8020af2a459b693c67cc56fe0fda7febfab6ee6`), signaling + capped, governance token RWAGMI.

Subgraph state confirms the inputs:

```
config.proposalType: 0   (signaling)
config.pointSystem:  1   (capped)
config.maxAmount:    1000000000000000000000000000
garden: RWAGMI, 18 decimals, 0xb200000000000000000000bf0548ab2ebd00ba5e
```

| | Before | After |
|---|---|---|
| Token | permanent spinner | row hidden |
| Max voting weight | `0 undefined` | `1,000,000,000 RWAGMI` |

## Notes on scope

- `EthAddress` is deliberately **not** changed. Its spinner fallback is legitimate for callers that resolve addresses asynchronously — still the case for funding/streaming pools, where `poolToken` loads after `PoolHeader` first renders. The bug was the caller passing an address that would never exist.
- Row filtering for funding and streaming pools is unchanged, including the existing signaling-only `value != null` guard.
- No contracts, subgraph mappings/schema, `usePoolToken`, `usePoolAmount`, or lockfile changes.

## Testing

Run from `apps/web`:

- `pnpm test:unit` — 18 files / 106 tests pass, including 4 new cases
- `pnpm typecheck` — clean
- `pnpm lint` — clean (one pre-existing unrelated warning in `campaigns/[campaignId]/page.tsx`)

New coverage in `utils/poolConfigLabels.test.ts`:

- capped signaling hides `Token` but keeps `Max voting weight`
- uncapped signaling hides both
- funding and streaming pools keep `Token`
- uncapped funding hides only `Max voting weight`
